### PR TITLE
Fix resource diff

### DIFF
--- a/resource/bundle.go
+++ b/resource/bundle.go
@@ -175,9 +175,9 @@ func (b Bundle) IsClean(
 
 			var chunks Chunks
 			if resource.Destroy {
-				chunks = Diff(currentState, nil)
+				chunks = DiffResourceState(resource.ManageableResource(), currentState, nil)
 			} else {
-				chunks = Diff(currentState, resource.State)
+				chunks = DiffResourceState(resource.ManageableResource(), currentState, resource.State)
 			}
 
 			if chunks.HaveChanges() {

--- a/resource/diff.go
+++ b/resource/diff.go
@@ -78,7 +78,8 @@ func (cs Chunks) String() string {
 	return buff.String()
 }
 
-func Diff(a, b interface{}) Chunks {
+// DiffAsYaml converts both interfaces to yaml and diffs them.
+func DiffAsYaml(a, b interface{}) Chunks {
 	var aStr string
 	if a != nil {
 		aBytes, err := yaml.Marshal(a)
@@ -101,4 +102,15 @@ func Diff(a, b interface{}) Chunks {
 		strings.Split(aStr, "\n"),
 		strings.Split(bStr, "\n"),
 	)
+}
+
+// DiffResourceState diffs two resource states, by using DiffableManageableResource if the
+// resource implements this interface, otherwise, use DiffAsYaml.
+func DiffResourceState(manageableResource ManageableResource, a, b State) Chunks {
+	diffableManageableResource, ok := manageableResource.(DiffableManageableResource)
+	if ok {
+		return diffableManageableResource.Diff(a, b)
+	} else {
+		return DiffAsYaml(a, b)
+	}
 }

--- a/resource/diff.go
+++ b/resource/diff.go
@@ -41,6 +41,7 @@ func (cs Chunks) added(i int, lines []string, buff *bytes.Buffer) {
 		}
 	}
 }
+
 func (cs Chunks) deleted(i int, lines []string, buff *bytes.Buffer) {
 	for _, line := range lines {
 		if (i == 0 || i == len(cs)-1) && line == "" {
@@ -57,6 +58,7 @@ func (cs Chunks) deleted(i int, lines []string, buff *bytes.Buffer) {
 		}
 	}
 }
+
 func (cs Chunks) equal(i int, lines []string, buff *bytes.Buffer) {
 	for _, line := range lines {
 		if (i == 0 || i == len(cs)-1) && line == "" {

--- a/resource/diff_test.go
+++ b/resource/diff_test.go
@@ -19,7 +19,7 @@ var d = `|-
     world
 `
 
-func TestDiff(t *testing.T) {
-	chunks := Diff(a, b)
+func TestDiffAsYaml(t *testing.T) {
+	chunks := DiffAsYaml(a, b)
 	require.Equal(t, d, chunks.String())
 }

--- a/resource/plan.go
+++ b/resource/plan.go
@@ -65,7 +65,7 @@ func (sai StepActionIndividual) Execute(ctx context.Context, hst host.Host) erro
 		if !ok {
 			panic(fmt.Errorf("TypeNameStateMap missing %s", sai.Resource.TypeName))
 		}
-		chunks := Diff(sai.Resource.State, currentState)
+		chunks := DiffResourceState(sai.Resource.ManageableResource(), currentState, sai.Resource.State)
 		if chunks.HaveChanges() {
 			logger.WithField("", chunks.String()).Errorf("💥 %s", sai.Resource)
 			return errors.New(
@@ -217,7 +217,7 @@ func (sam StepActionMerged) Execute(ctx context.Context, hst host.Host) error {
 		if !ok {
 			panic(fmt.Sprintf("typeNameResourceMap missing %s", typeName))
 		}
-		chunks := Diff(resource.State, currentState)
+		chunks := DiffResourceState(sam.MustMergeableManageableResources(), currentState, resource.State)
 		if chunks.HaveChanges() {
 			logger.WithField("", chunks.String()).Errorf("💥 %s", typeName)
 			return fmt.Errorf(
@@ -445,7 +445,7 @@ func (p Plan) printResource(
 		panic(fmt.Sprintf("State not found at TypeNameStateMap: %s", resource.TypeName))
 	}
 
-	chunks := Diff(currentState, resource.State)
+	chunks := DiffResourceState(resource.ManageableResource(), currentState, resource.State)
 
 	var action Action
 	for actionResources, stepResources := range step.ActionResourcesMap() {
@@ -542,7 +542,7 @@ func (p Plan) addBundleSteps(
 				panic(fmt.Errorf("State missing from TypeNameStateMap: %s", newResource.TypeName))
 			}
 
-			chunks := Diff(currentState, newResource.State)
+			chunks := DiffResourceState(newResource.ManageableResource(), currentState, newResource.State)
 
 			clean := !chunks.HaveChanges()
 

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -58,6 +58,16 @@ type RefreshableManageableResource interface {
 	Refresh(ctx context.Context, hst host.Host, name Name) error
 }
 
+// DiffableManageableResource defines an interface for resources to implement their own state
+// diff logic.
+type DiffableManageableResource interface {
+	ManageableResource
+
+	// Diff compares the two States. If b is satisfied by a, it returns empty Chunks. Otherwise,
+	// returns the diff between a and b.
+	Diff(a, b State) Chunks
+}
+
 // IndividuallyManageableResource is an interface for managing a single resource name.
 // This is the most common use case, where resources can be individually managed without one resource
 // having dependency on others and changing one resource does not affect the state of another.

--- a/resource/types/apt_package.go
+++ b/resource/types/apt_package.go
@@ -36,6 +36,15 @@ func (ap APTPackage) ValidateName(name resource.Name) error {
 	return nil
 }
 
+func (ap APTPackage) Diff(a, b resource.State) resource.Chunks {
+	aptPackageStateA := a.(APTPackageState)
+	aptPackageStateB := b.(APTPackageState)
+	if aptPackageStateB.Version == "" {
+		aptPackageStateB.Version = aptPackageStateA.Version
+	}
+	return resource.DiffAsYaml(aptPackageStateA, aptPackageStateB)
+}
+
 var aptPackageRegexpNotFound = regexp.MustCompile(`^dpkg-query: no packages found matching (.+)$`)
 
 func (ap APTPackage) GetStates(


### PR DESCRIPTION
For cases such as `APTPackage` and no version set, any existing version sholud be accepted, but as it stands currently `"1.0"` != `""`, so things fail.

This PR adds an interface for such resource types, so they can define their own definition of diff two states to account for such idiosyncrasies.