### PR TITLE
Rename baseRun to cmdRun

### DIFF
--- a/internal/host/cmd_run.go
+++ b/internal/host/cmd_run.go
@@ -20,11 +20,16 @@ import (
 	"github.com/fornellas/resonance/log"
 )
 
-type baseRun struct {
+// This partially implements host.Host interface, with the exception of the following functions:
+// Run, String and Close. Full implementtations of the host.Host interface can embed this struct,
+// and just implement the remaining methods.
+// The use case for this is for share code across host.Host implementations that solely rely
+// on spawning commands via Run.
+type cmdHost struct {
 	Host host.Host
 }
 
-func (br baseRun) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+func (br cmdHost) Chmod(ctx context.Context, name string, mode os.FileMode) error {
 	logger := log.GetLogger(ctx)
 	logger.Debugf("Chmod %v %s", mode, name)
 	nestedCtx := log.IndentLogger(ctx)
@@ -55,7 +60,7 @@ func (br baseRun) Chmod(ctx context.Context, name string, mode os.FileMode) erro
 	)
 }
 
-func (br baseRun) Chown(ctx context.Context, name string, uid, gid int) error {
+func (br cmdHost) Chown(ctx context.Context, name string, uid, gid int) error {
 	logger := log.GetLogger(ctx)
 	logger.Debugf("Chown %v %v %s", uid, gid, name)
 	nestedCtx := log.IndentLogger(ctx)
@@ -86,7 +91,7 @@ func (br baseRun) Chown(ctx context.Context, name string, uid, gid int) error {
 	)
 }
 
-func (br baseRun) Lookup(ctx context.Context, username string) (*user.User, error) {
+func (br cmdHost) Lookup(ctx context.Context, username string) (*user.User, error) {
 	logger := log.GetLogger(ctx)
 	logger.Debugf("Lookup %s", username)
 	nestedCtx := log.IndentLogger(ctx)
@@ -134,7 +139,7 @@ func (br baseRun) Lookup(ctx context.Context, username string) (*user.User, erro
 	return nil, user.UnknownUserError(username)
 }
 
-func (br baseRun) LookupGroup(ctx context.Context, name string) (*user.Group, error) {
+func (br cmdHost) LookupGroup(ctx context.Context, name string) (*user.Group, error) {
 	logger := log.GetLogger(ctx)
 	logger.Debugf("LookupGroup %s", name)
 	nestedCtx := log.IndentLogger(ctx)
@@ -176,7 +181,7 @@ func (br baseRun) LookupGroup(ctx context.Context, name string) (*user.Group, er
 	return nil, user.UnknownGroupError(name)
 }
 
-func (br baseRun) stat(ctx context.Context, name string) (string, error) {
+func (br cmdHost) stat(ctx context.Context, name string) (string, error) {
 	cmd := host.Cmd{
 		Path: "stat",
 		Args: []string{"--format=%d,%i,%h,%f,%u,%g,%t,%T,%s,%o,%b,%x,%y,%z", name},
@@ -200,7 +205,7 @@ func (br baseRun) stat(ctx context.Context, name string) (string, error) {
 	return stdout, nil
 }
 
-func (br baseRun) Lstat(ctx context.Context, name string) (host.HostFileInfo, error) {
+func (br cmdHost) Lstat(ctx context.Context, name string) (host.HostFileInfo, error) {
 	logger := log.GetLogger(ctx)
 	logger.Debugf("Lstat %s", name)
 	nestedCtx := log.IndentLogger(ctx)
@@ -288,7 +293,7 @@ func (br baseRun) Lstat(ctx context.Context, name string) (host.HostFileInfo, er
 	}, nil
 }
 
-func (br baseRun) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
+func (br cmdHost) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
 	logger := log.GetLogger(ctx)
 	logger.Debugf("Mkdir %s", name)
 	nestedCtx := log.IndentLogger(ctx)
@@ -320,7 +325,7 @@ func (br baseRun) Mkdir(ctx context.Context, name string, perm os.FileMode) erro
 	return br.Chmod(ctx, name, perm)
 }
 
-func (br baseRun) ReadFile(ctx context.Context, name string) ([]byte, error) {
+func (br cmdHost) ReadFile(ctx context.Context, name string) ([]byte, error) {
 	logger := log.GetLogger(ctx)
 	logger.Debugf("ReadFile %s", name)
 	nestedCtx := log.IndentLogger(ctx)
@@ -348,7 +353,7 @@ func (br baseRun) ReadFile(ctx context.Context, name string) ([]byte, error) {
 	return []byte(stdout), nil
 }
 
-func (br baseRun) rmdir(ctx context.Context, name string) error {
+func (br cmdHost) rmdir(ctx context.Context, name string) error {
 	cmd := host.Cmd{
 		Path: "rmdir",
 		Args: []string{name},
@@ -369,7 +374,7 @@ func (br baseRun) rmdir(ctx context.Context, name string) error {
 	return nil
 }
 
-func (br baseRun) Remove(ctx context.Context, name string) error {
+func (br cmdHost) Remove(ctx context.Context, name string) error {
 	logger := log.GetLogger(ctx)
 	logger.Debugf("Remove %s", name)
 	nestedCtx := log.IndentLogger(ctx)
@@ -400,7 +405,7 @@ func (br baseRun) Remove(ctx context.Context, name string) error {
 	return nil
 }
 
-func (br baseRun) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+func (br cmdHost) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
 	logger := log.GetLogger(ctx)
 	logger.Debugf("WriteFile %s %v", name, perm)
 	nestedCtx := log.IndentLogger(ctx)

--- a/internal/host/cmd_run_linux_test.go
+++ b/internal/host/cmd_run_linux_test.go
@@ -12,75 +12,75 @@ import (
 	"github.com/fornellas/resonance/host"
 )
 
-type baseRunOnly struct {
+type cmdHostOnly struct {
 	T    *testing.T
 	Host host.Host
 }
 
-func (bro baseRunOnly) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+func (h cmdHostOnly) Chmod(ctx context.Context, name string, mode os.FileMode) error {
 	err := errors.New("unexpected call received: Chmod")
-	bro.T.Fatal(err)
+	h.T.Fatal(err)
 	return err
 }
 
-func (bro baseRunOnly) Chown(ctx context.Context, name string, uid, gid int) error {
+func (h cmdHostOnly) Chown(ctx context.Context, name string, uid, gid int) error {
 	err := errors.New("unexpected call received: Chown")
-	bro.T.Fatal(err)
+	h.T.Fatal(err)
 	return err
 }
 
-func (bro baseRunOnly) Lookup(ctx context.Context, username string) (*user.User, error) {
+func (h cmdHostOnly) Lookup(ctx context.Context, username string) (*user.User, error) {
 	err := errors.New("unexpected call received: Lookup")
-	bro.T.Fatal(err)
+	h.T.Fatal(err)
 	return nil, err
 }
 
-func (bro baseRunOnly) LookupGroup(ctx context.Context, name string) (*user.Group, error) {
+func (h cmdHostOnly) LookupGroup(ctx context.Context, name string) (*user.Group, error) {
 	err := errors.New("unexpected call received: LookupGroup")
-	bro.T.Fatal(err)
+	h.T.Fatal(err)
 	return nil, err
 }
 
-func (bro baseRunOnly) Lstat(ctx context.Context, name string) (host.HostFileInfo, error) {
+func (h cmdHostOnly) Lstat(ctx context.Context, name string) (host.HostFileInfo, error) {
 	err := errors.New("unexpected call received: Lstat")
-	bro.T.Fatal(err)
+	h.T.Fatal(err)
 	return host.HostFileInfo{}, err
 }
 
-func (bro baseRunOnly) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
+func (h cmdHostOnly) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
 	err := errors.New("unexpected call received: Mkdir")
-	bro.T.Fatal(err)
+	h.T.Fatal(err)
 	return err
 }
 
-func (bro baseRunOnly) ReadFile(ctx context.Context, name string) ([]byte, error) {
+func (h cmdHostOnly) ReadFile(ctx context.Context, name string) ([]byte, error) {
 	err := errors.New("unexpected call received: ReadFile")
-	bro.T.Fatal(err)
+	h.T.Fatal(err)
 	return nil, err
 }
 
-func (bro baseRunOnly) Remove(ctx context.Context, name string) error {
+func (h cmdHostOnly) Remove(ctx context.Context, name string) error {
 	err := errors.New("unexpected call received: Remove")
-	bro.T.Fatal(err)
+	h.T.Fatal(err)
 	return err
 }
 
-func (bro baseRunOnly) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+func (h cmdHostOnly) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
 	err := errors.New("unexpected call received: WriteFile")
-	bro.T.Fatal(err)
+	h.T.Fatal(err)
 	return err
 }
 
-func (bro baseRunOnly) String() string {
-	return bro.Host.String()
+func (h cmdHostOnly) String() string {
+	return h.Host.String()
 }
 
-func (bro baseRunOnly) Close() error {
-	return bro.Host.Close()
+func (h cmdHostOnly) Close() error {
+	return h.Host.Close()
 }
 
 type localRunOnly struct {
-	baseRunOnly
+	cmdHostOnly
 	Host host.Host
 }
 
@@ -92,13 +92,13 @@ func newLocalRunOnly(t *testing.T, host host.Host) localRunOnly {
 	run := localRunOnly{
 		Host: host,
 	}
-	run.baseRunOnly.T = t
-	run.baseRunOnly.Host = host
+	run.cmdHostOnly.T = t
+	run.cmdHostOnly.Host = host
 	return run
 }
 
 type runner struct {
-	baseRun
+	cmdHost
 	Host host.Host
 }
 
@@ -118,11 +118,11 @@ func newRunner(host host.Host) runner {
 	run := runner{
 		Host: host,
 	}
-	run.baseRun.Host = host
+	run.cmdHost.Host = host
 	return run
 }
 
-func TestBaseRun(t *testing.T) {
+func TestCmdHost(t *testing.T) {
 	host := newRunner(newLocalRunOnly(t, Local{}))
 	testHost(t, host)
 	defer func() { require.NoError(t, host.Close()) }()

--- a/internal/host/docker_unix.go
+++ b/internal/host/docker_unix.go
@@ -14,9 +14,18 @@ import (
 
 // Docker uses docker exec to target a running container.
 type Docker struct {
-	baseRun
+	cmdHost
 	Container string
 	User      string
+}
+
+func NewDocker(ctx context.Context, container, user string) (Docker, error) {
+	dockerHst := Docker{
+		Container: container,
+		User:      user,
+	}
+	dockerHst.cmdHost.Host = &dockerHst
+	return dockerHst, nil
 }
 
 func (d Docker) Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus, error) {
@@ -70,7 +79,6 @@ func (d Docker) Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus, error) 
 		waitStatus.Signal = signal.String()
 	}
 	return waitStatus, nil
-
 }
 
 func (d Docker) String() string {
@@ -79,13 +87,4 @@ func (d Docker) String() string {
 
 func (d Docker) Close() error {
 	return nil
-}
-
-func NewDocker(ctx context.Context, container, user string) (Docker, error) {
-	dockerHst := Docker{
-		Container: container,
-		User:      user,
-	}
-	dockerHst.baseRun.Host = &dockerHst
-	return dockerHst, nil
 }

--- a/internal/host/sudo_linux_test.go
+++ b/internal/host/sudo_linux_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 type localRunSudoOnly struct {
-	baseRunOnly
+	cmdHostOnly
 	T    *testing.T
 	Host host.Host
 }
@@ -46,8 +46,8 @@ func newLocalRunSudoOnly(t *testing.T, hst host.Host) localRunSudoOnly {
 		T:    t,
 		Host: hst,
 	}
-	run.baseRunOnly.T = t
-	run.baseRunOnly.Host = hst
+	run.cmdHostOnly.T = t
+	run.cmdHostOnly.Host = hst
 	return run
 }
 


### PR DESCRIPTION
The `baseRun` type had a pretty bad name and was missing documentation. This PR should address this, hopefully making the code easier to understand.

It is also moving all `New*` methods closer to the type, following the order that go documentation uses.