### PR TITLE
Upgrade golang.org/x/image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/williammartin/subreaper v0.0.0-20181101193406-731d9ece6883 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20240613232115-7f521ea00fb8 // indirect
-	golang.org/x/image v0.14.0 // indirect
+	golang.org/x/image v0.18.0 // indirect
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/exp/typeparams v0.0.0-20240613232115-7f521ea00fb8 h1:+ZJmEdDFzH5H0CnzOrwgbH3elHctfTecW9X0k2tkn5M=
 golang.org/x/exp/typeparams v0.0.0-20240613232115-7f521ea00fb8/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
-golang.org/x/image v0.14.0 h1:tNgSxAFe3jC4uYqvZdTr84SZoM1KfwdC9SKIFrLjFn4=
-golang.org/x/image v0.14.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
+golang.org/x/image v0.18.0 h1:jGzIakQa/ZXI1I0Fxvaa9W7yP25TqT6cHIHn+6CqvSQ=
+golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
 golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=
 golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=


### PR DESCRIPTION
Dependabot raised this https://github.com/fornellas/resonance/security/dependabot/6.

I tried doing `go get -u`, but it seems someone did something clowny and broke indirect dependencies:

I'm shamelesslly just updating what's being complained, in the hops that this screw up resolves itself with time, so I don't have to resolve it :-D

```
$ go get -u
go: github.com/alessio/shellescape@v1.5.0: parsing go.mod:
        module declares its path as: al.essio.dev/pkg/shellescape
                but was required as: github.com/alessio/shellescape
        trying github.com/alessio/shellescape@v1.5.0-rc1
go: github.com/alessio/shellescape@v1.5.0-rc1: parsing go.mod:
        module declares its path as: al.essio.dev/pkg/shellescape
                but was required as: github.com/alessio/shellescape
        restoring github.com/alessio/shellescape@v1.4.2
go: github.com/alessio/shellescape@v1.5.0: parsing go.mod:
        module declares its path as: al.essio.dev/pkg/shellescape
                but was required as: github.com/alessio/shellescape
        trying github.com/alessio/shellescape@v1.5.0-rc1
go: github.com/alessio/shellescape@v1.5.0-rc1: parsing go.mod:
        module declares its path as: al.essio.dev/pkg/shellescape
                but was required as: github.com/alessio/shellescape
        restoring github.com/alessio/shellescape@v1.4.2
go: upgraded golang.org/x/exp/typeparams v0.0.0-20240613232115-7f521ea00fb8 => v0.0.0-20240719175910-8a7402abbf56
```

Depends on #56  for the build to work.