### PR TITLE
Improve Nodes String logic

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -54,22 +53,21 @@ var ValidateCmd = &cobra.Command{
 			}
 		}
 
-		hostState, err := iResouresPkg.NewHostState(resources)
+		nodes, err := iResouresPkg.NewNodes(resources)
 		if err != nil {
 			logger.Error(err.Error())
 			Exit(1)
 		}
 
-		if err := hostState.Update(ctx, hst); err != nil {
+		if err := nodes.Update(ctx, hst); err != nil {
 			logger.Error(err.Error())
 			Exit(1)
 		}
 
-		logger.Info("📦 Catalog: \n   Planning to apply ... ")
-		for index, node := range hostState {
-			index++
-			fmt.Printf("    %v. %s\n", index, node)
-		}
+		logger.Info(
+			"📦 Resources",
+			"resources", iResouresPkg.Nodes(nodes).String(),
+		)
 
 		logger.Info("🎆 Validation successful")
 	},


### PR DESCRIPTION
Build on top of @gfechio changes, to move the `String()` logic to the right place.

```
$ ./resonance.linux.amd64 validate --localhost foo.yaml 
🔍 Validating
  path: foo.yaml
  host: localhost
📝 Loading file
  path: foo.yaml
📦 Resources
  resources:
    1. APTPackages: bar,foo
    2. File: /tmp/foo
    3. File: /tmp/bar
🎆 Validation successful
```

PS: I reckon that "Nodes" ain't the best name, and I'd like to tackle that on a future PR.