### PR TITLE
Add GO_BUILD_AGENT_NATIVE_ONLY=1 to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ And then start you code editor from the development shell (eg: for Sublime, do `
 The default build (`ci`) gives you the best signal, but it may not be fast enough during development. You can disable some features, which should speed up things during development:
 
 ```shell
-./build.sh ci GO_TEST_NO_COVER=1 GO_BUILD_FLAGS_NO_RACE=1
+./build.sh ci GO_TEST_NO_COVER=1 GO_BUILD_FLAGS_NO_RACE=1 GO_BUILD_AGENT_NATIVE_ONLY=1
 ```
 
 ### Automatic builds on Linux


### PR DESCRIPTION
@gfechio you asked about this, it exists, but was missing from `README.md`. Let's add it.