### PR TITLE
Update coveralls

### DIFF
--- a/.github/workflows/build-darwin.yaml
+++ b/.github/workflows/build-darwin.yaml
@@ -80,7 +80,7 @@ jobs:
           if-no-files-found: error
       # Coveralls
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.0
         with:
           file: cover.lcov
           flag-name: darwin.${{ inputs.GOARCH }}

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -76,7 +76,7 @@ jobs:
           if-no-files-found: error
       # Coveralls
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.0
         with:
           file: cover.lcov
           flag-name: linux.${{ inputs.GOARCH }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -48,6 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: coverallsapp/github-action@v1
+      uses: coverallsapp/github-action@v2.3.0
       with:
         parallel-finished: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -104,6 +104,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: coverallsapp/github-action@v1
+      uses: coverallsapp/github-action@v2.3.0
       with:
         parallel-finished: true


### PR DESCRIPTION
And avoid warnings:

```
The following actions uses Node.js version which is deprecated and will be forced to run on node20: coverallsapp/github-action@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```