### PR TITLE
Implement basic host store

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -57,6 +57,7 @@ var PlanCmd = &cobra.Command{
 		}
 
 		if lastBlueprint == nil {
+			logger.Info("🚫 No previous Blueprint")
 			lastBlueprint, err := targetBlueprint.Load(ctx, hst)
 			if err != nil {
 				logger.Error(err.Error())

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/fornellas/resonance/host"
 	"github.com/fornellas/resonance/log"
 	resourcesPkg "github.com/fornellas/resonance/resources"
@@ -20,13 +22,13 @@ type Step struct {
 	requiredBy     []*Step
 }
 
-func newSingleResourceStep(singleResource resourcesPkg.SingleResource) *Step {
+func NewSingleResourceStep(singleResource resourcesPkg.SingleResource) *Step {
 	return &Step{
 		singleResource: singleResource,
 	}
 }
 
-func newGroupResourceStep(groupResource resourcesPkg.GroupResource) *Step {
+func NewGroupResourceStep(groupResource resourcesPkg.GroupResource) *Step {
 	return &Step{
 		groupResource: groupResource,
 	}
@@ -50,7 +52,7 @@ func (s *Step) String() string {
 	panic("bug: invalid state")
 }
 
-func (s *Step) appendGroupResource(resource resourcesPkg.Resource) {
+func (s *Step) AppendGroupResource(resource resourcesPkg.Resource) {
 	if s.groupResource == nil {
 		panic("bug: can't add Resource to non GroupResource Step")
 	}
@@ -128,7 +130,7 @@ func (s *Step) load(ctx context.Context, hst host.Host) (*Step, error) {
 }
 
 func (s *Step) MarshalYAML() (interface{}, error) {
-	type marshalSchema struct {
+	type MarshalSchema struct {
 		SingleResourceType string                      `yaml:"single_resource_type,omitempty"`
 		SingleResource     resourcesPkg.SingleResource `yaml:"single_resource,omitempty"`
 		GroupResourceType  string                      `yaml:"group_resource_type,omitempty"`
@@ -148,13 +150,61 @@ func (s *Step) MarshalYAML() (interface{}, error) {
 		groupResourcesType = reflect.TypeOf(s.groupResources[0]).Elem().Name()
 	}
 
-	return &marshalSchema{
+	return &MarshalSchema{
 		SingleResourceType: singleResourceType,
 		SingleResource:     s.singleResource,
 		GroupResourceType:  groupResourceType,
 		GroupResourcesType: groupResourcesType,
 		GroupResources:     s.groupResources,
 	}, nil
+}
+
+func (s *Step) UnmarshalYAML(node *yaml.Node) error {
+	type UnmarshalSchema struct {
+		SingleResourceType *string                `yaml:"single_resource_type"`
+		SingleResourceNode yaml.Node              `yaml:"single_resource"`
+		GroupResourceType  *string                `yaml:"group_resource_type"`
+		GroupResourcesType *string                `yaml:"group_resources_type"`
+		GroupResources     resourcesPkg.Resources `yaml:"group_resources"`
+	}
+
+	step := &UnmarshalSchema{}
+
+	node.KnownFields(true)
+	err := node.Decode(step)
+	if err != nil {
+		return fmt.Errorf("line %d: %s", node.Line, err.Error())
+	}
+
+	if step.SingleResourceType != nil {
+		s.singleResource = resourcesPkg.GetSingleResourceByTypeName(*step.SingleResourceType)
+		if s.singleResource == nil {
+			return fmt.Errorf("line %d: invalid single resource type: %#v ", node.Line, *step.SingleResourceType)
+		}
+		step.SingleResourceNode.KnownFields(true)
+		err := step.SingleResourceNode.Decode(s.singleResource)
+		if err != nil {
+			return fmt.Errorf("line %d: %s", node.Line, err.Error())
+		}
+	}
+
+	if step.GroupResourceType != nil {
+		s.groupResource = resourcesPkg.GetGroupResourceByTypeName(*step.GroupResourcesType)
+		if s.groupResource == nil {
+			return fmt.Errorf("line %d: invalid group resource type: %#v ", node.Line, *step.GroupResourceType)
+		}
+		s.groupResources = step.GroupResources
+	}
+
+	if s.singleResource != nil && s.groupResource != nil {
+		panic("bug: YAML contents does not reflect schema: it defines both SingleResource and GroupResource")
+	}
+
+	if s.singleResource == nil && s.groupResource == nil {
+		panic("bug: YAML contents does not reflect schema: it does not define either SingleResource or GroupResource")
+	}
+
+	return nil
 }
 
 // Blueprint holds a full desired state for a host.
@@ -177,19 +227,21 @@ func newBlueprintFromRessources(resources resourcesPkg.Resources) Blueprint {
 			var ok bool
 			step, ok = typeToStepMap[typeName]
 			if !ok {
-				step = newGroupResourceStep(
-					resourcesPkg.GetGroupResourceByTypeName(typeName),
-				)
+				groupResource := resourcesPkg.GetGroupResourceByTypeName(typeName)
+				if groupResource == nil {
+					panic("bug: invalid resource type")
+				}
+				step = NewGroupResourceStep(groupResource)
 				typeToStepMap[typeName] = step
 				blueprint = append(blueprint, step)
 			}
-			step.appendGroupResource(resource)
+			step.AppendGroupResource(resource)
 		} else {
 			singleResource, ok := resource.(resourcesPkg.SingleResource)
 			if !ok {
-				panic("bug: Resource is not SingleResource")
+				panic(fmt.Sprintf("bug: Resource is not SingleResource: %#v", resource))
 			}
-			step = newSingleResourceStep(singleResource)
+			step = NewSingleResourceStep(singleResource)
 			blueprint = append(blueprint, step)
 		}
 
@@ -308,6 +360,8 @@ func (b Blueprint) resolve(ctx context.Context, hst host.Host) error {
 
 // Load returns a copy of the Blueprint, with all resource states loaded from given Host.
 func (b Blueprint) Load(ctx context.Context, hst host.Host) (Blueprint, error) {
+	logger := log.MustLogger(ctx)
+	logger.Info("🔍 Loading Blueprint from host")
 	newBlueprint := make(Blueprint, len(b))
 	for i, step := range b {
 		newStep, err := step.load(ctx, hst)

--- a/internal/blueprint/blueprint_test.go
+++ b/internal/blueprint/blueprint_test.go
@@ -1,0 +1,75 @@
+package blueprint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/fornellas/resonance/resources"
+)
+
+func TestStepYaml(t *testing.T) {
+	t.Run("SingleResource", func(t *testing.T) {
+		testStep := NewSingleResourceStep(&resources.File{
+			Path: "/tmp/foo",
+			Perm: 0644,
+		})
+
+		testStepYamlStr := `single_resource_type: File
+single_resource:
+    path: /tmp/foo
+    content: ""
+    perm: 420
+    uid: 0
+    gid: 0
+`
+
+		t.Run("Marshal", func(t *testing.T) {
+			bs, err := yaml.Marshal(testStep)
+			require.NoError(t, err)
+
+			require.Equal(t, testStepYamlStr, string(bs))
+		})
+
+		t.Run("Unmarshal", func(t *testing.T) {
+			unmarshaledStep := Step{}
+			err := yaml.Unmarshal([]byte(testStepYamlStr), &unmarshaledStep)
+			require.NoError(t, err)
+			require.Equal(t, testStep, &unmarshaledStep)
+		})
+	})
+
+	t.Run("GroupResource", func(t *testing.T) {
+		testStep := NewGroupResourceStep(&resources.APTPackages{})
+		testStep.AppendGroupResource(&resources.APTPackage{
+			Package: "foo",
+		})
+		testStep.AppendGroupResource(&resources.APTPackage{
+			Package: "bar",
+		})
+
+		testStepYamlStr := `group_resource_type: APTPackages
+group_resources_type: APTPackage
+group_resources:
+    - APTPackage:
+        package: foo
+    - APTPackage:
+        package: bar
+`
+
+		t.Run("Marshal", func(t *testing.T) {
+			bs, err := yaml.Marshal(testStep)
+			require.NoError(t, err)
+
+			require.Equal(t, testStepYamlStr, string(bs))
+		})
+
+		t.Run("Unmarshal", func(t *testing.T) {
+			unmarshaledStep := Step{}
+			err := yaml.Unmarshal([]byte(testStepYamlStr), &unmarshaledStep)
+			require.NoError(t, err)
+			require.Equal(t, testStep, &unmarshaledStep)
+		})
+	})
+}

--- a/internal/store/host.go
+++ b/internal/store/host.go
@@ -2,6 +2,13 @@ package store
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/fornellas/resonance/host"
 	blueprintPkg "github.com/fornellas/resonance/internal/blueprint"
@@ -23,14 +30,44 @@ func NewHostStore(hst host.Host) *HostStore {
 	}
 }
 
-func (s *HostStore) GetLastBlueprint(ctx context.Context) (blueprintPkg.Blueprint, error) {
-	logger := log.MustLogger(ctx).WithGroup("host_store")
-	// ctx = log.WithLogger(ctx, logger)
-	logger.Info("Computing blueprint")
+func (s *HostStore) getYamlPath() string {
+	return filepath.Join(HostStorePath, "blueprint.yaml")
+}
 
-	panic("TODO")
+func (s *HostStore) GetLastBlueprint(ctx context.Context) (blueprintPkg.Blueprint, error) {
+	logger := log.MustLogger(ctx)
+	logger.Info("📂 Loading last stored Bueprint")
+	blueprintBytes, err := s.Host.ReadFile(ctx, s.getYamlPath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	blueprint := blueprintPkg.Blueprint{}
+	err = yaml.Unmarshal(blueprintBytes, &blueprint)
+	if err != nil {
+		return nil, err
+	}
+
+	return blueprint, nil
 }
 
 func (s *HostStore) Save(ctx context.Context, blueprint blueprintPkg.Blueprint) error {
-	panic("TODO")
+	logger := log.MustLogger(ctx)
+	logger.Info("💾 Saving Bueprint to host")
+
+	blueprintBytes, err := yaml.Marshal(blueprint)
+	if err != nil {
+		panic(fmt.Sprintf("bug: failed to serialize blueprint: %s", err.Error()))
+	}
+
+	dir := filepath.Dir(s.getYamlPath())
+
+	if err := os.MkdirAll(dir, fs.FileMode(0700)); err != nil {
+		return err
+	}
+
+	return s.Host.WriteFile(ctx, s.getYamlPath(), blueprintBytes, os.FileMode(0600))
 }

--- a/resources/file.go
+++ b/resources/file.go
@@ -59,6 +59,7 @@ func (f *File) Validate() error {
 		if f.Group != "" {
 			return fmt.Errorf("'group' can not be set when 'remove' is true")
 		}
+		return nil
 	}
 
 	if f.Perm == os.FileMode(0) {

--- a/resources/resources_test.go
+++ b/resources/resources_test.go
@@ -1,0 +1,176 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestResourcesYAML(t *testing.T) {
+	testResources := Resources{
+		&File{
+			Path: "/tmp/foo",
+			Perm: 0644,
+		},
+		&APTPackage{
+			Package: "foo",
+		},
+	}
+
+	testResourcesYamlStr := `- File:
+    path: /tmp/foo
+    content: ""
+    perm: 420
+    uid: 0
+    gid: 0
+- APTPackage:
+    package: foo
+`
+
+	t.Run("Marshal", func(t *testing.T) {
+		bs, err := yaml.Marshal(testResources)
+		require.NoError(t, err)
+
+		require.Equal(t, testResourcesYamlStr, string(bs))
+	})
+
+	t.Run("Unmarshal", func(t *testing.T) {
+		unmarshaledResources := Resources{}
+		err := yaml.Unmarshal([]byte(testResourcesYamlStr), &unmarshaledResources)
+		require.NoError(t, err)
+		require.Equal(t, testResources, unmarshaledResources)
+	})
+}
+
+func TestGetResourceId(t *testing.T) {
+	type TestCase struct {
+		Resource Resource
+		Id       string
+	}
+
+	for _, tc := range []TestCase{
+		{
+			Resource: &File{
+				Path: "/tmp/foo",
+				Perm: 0644,
+			},
+			Id: "/tmp/foo",
+		},
+		{
+			Resource: &APTPackage{
+				Package: "foo",
+				Version: "1",
+			},
+			Id: "foo",
+		},
+	} {
+		require.Equal(t, tc.Id, GetResourceId(tc.Resource))
+	}
+}
+
+func TestGetResourceByTypeName(t *testing.T) {
+	type TestCase struct {
+		Name     string
+		Resource Resource
+	}
+
+	for _, tc := range []TestCase{
+		{
+			Name:     "File",
+			Resource: &File{},
+		},
+		{
+			Name:     "APTPackage",
+			Resource: &APTPackage{},
+		},
+	} {
+		resource := GetResourceByTypeName(tc.Name)
+		require.Equal(t, tc.Resource, resource)
+	}
+}
+
+func TestGetResourceTypeNames(t *testing.T) {
+	require.Equal(t, []string{"APTPackage", "File"}, GetResourceTypeNames())
+}
+
+func TestNewResourceCopyWithOnlyId(t *testing.T) {
+	type TestCase struct {
+		Resource               Resource
+		ResourceCopyWithOnlyId Resource
+	}
+
+	for _, tc := range []TestCase{
+		{
+			Resource: &File{
+				Path: "/tmp/foo",
+				Perm: 0644,
+			},
+			ResourceCopyWithOnlyId: &File{
+				Path: "/tmp/foo",
+			},
+		},
+		{
+			Resource: &APTPackage{
+				Package: "foo",
+				Version: "1",
+			},
+			ResourceCopyWithOnlyId: &APTPackage{
+				Package: "foo",
+			},
+		},
+	} {
+		require.Equal(
+			t,
+			tc.ResourceCopyWithOnlyId,
+			NewResourceCopyWithOnlyId(tc.Resource),
+		)
+	}
+}
+
+func TestNewResourcesCopyWithOnlyId(t *testing.T) {
+	require.Equal(
+		t,
+		Resources{
+			&File{
+				Path: "/tmp/foo",
+			},
+			&APTPackage{
+				Package: "foo",
+			},
+		},
+		NewResourcesCopyWithOnlyId(
+			Resources{
+				&File{
+					Path: "/tmp/foo",
+					Perm: 0644,
+				},
+				&APTPackage{
+					Package: "foo",
+					Version: "1",
+				},
+			},
+		),
+	)
+}
+
+func TestGetSingleResourceByTypeName(t *testing.T) {
+	require.Equal(
+		t,
+		&File{},
+		GetSingleResourceByTypeName("File"),
+	)
+}
+
+func TestGetGroupResourceByTypeName(t *testing.T) {
+	require.Equal(
+		t,
+		&APTPackages{},
+		GetGroupResourceByTypeName("APTPackage"),
+	)
+}
+
+func TestIsGroupResource(t *testing.T) {
+	require.False(t, IsGroupResource("File"))
+	require.True(t, IsGroupResource("APTPackage"))
+}


### PR DESCRIPTION
Follow up to #60.

Implement a basic `Store` that's able to store the `Blueprint` and load it after. This let's the plan command move a bit further ahead. Next & final stop, actually calculating the plan (last TODO in the code).

This required fixing various random bugs, and implement marshaling for some types. These marshalings are a bit tricky, as the structs have the interface references, but we must marshal the contrete type, and unmarshal it back to the interface. I've added tests to cover that.