### PR TITLE
Tame agent size

### DIFF
--- a/internal/host/agent_server/agent_linux.go
+++ b/internal/host/agent_server/agent_linux.go
@@ -21,9 +21,9 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/fornellas/resonance/host"
-	iHost "github.com/fornellas/resonance/internal/host"
 	"github.com/fornellas/resonance/internal/host/agent_server/api"
 	aNet "github.com/fornellas/resonance/internal/host/agent_server/net"
+	"github.com/fornellas/resonance/internal/host/local_run"
 )
 
 func internalServerError(w http.ResponseWriter, err error) {
@@ -267,7 +267,7 @@ func PostRunFn(ctx context.Context) func(http.ResponseWriter, *http.Request) {
 			Stderr: stderrBuff,
 		}
 
-		waitStatus, err := iHost.LocalRun(ctx, cmd)
+		waitStatus, err := local_run.Run(ctx, cmd)
 		if err != nil {
 			internalServerError(w, err)
 			return

--- a/internal/host/local_linux.go
+++ b/internal/host/local_linux.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/fornellas/resonance/host"
+	"github.com/fornellas/resonance/internal/host/local_run"
 	"github.com/fornellas/resonance/log"
 )
 
@@ -78,7 +79,7 @@ func (l Local) Remove(ctx context.Context, name string) error {
 func (l Local) Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus, error) {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Run", "cmd", cmd)
-	return LocalRun(ctx, cmd)
+	return local_run.Run(ctx, cmd)
 }
 
 func (l Local) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {

--- a/internal/host/local_run/local_run_unix.go
+++ b/internal/host/local_run/local_run_unix.go
@@ -1,4 +1,4 @@
-package host
+package local_run
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 )
 
 // Implements Host.Run for unix locahost.
-func LocalRun(ctx context.Context, cmd host.Cmd) (host.WaitStatus, error) {
+func Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus, error) {
 	execCmd := exec.CommandContext(ctx, cmd.Path, cmd.Args...)
 	if len(cmd.Env) == 0 {
 		cmd.Env = []string{"LANG=en_US.UTF-8"}


### PR DESCRIPTION
I've noticed the build started to take longer recently... and [found the culpid](https://github.com/fornellas/resonance/issues/17#issuecomment-2267747277) (thanks `git bisect`): https://github.com/fornellas/resonance/commit/30ad492345a6123ad59449a89010458f80c93ca3 balooned the agent size.

I'm not totally sure why that is, as I'd expect the go compiler to not include all non-used symbols in the agent package, but... I've also read some coments on "if you use reflect all bets are off", so... ¯\_(ツ)_/¯

Whatever the case... let's rollback the change, and get back to tame levels.

I've also added a check on CI, to prevent agent size from balooning without notice again.

Closes #17.