### PR TITLE
Fix update job permissions

### DIFF
--- a/.github/workflows/update_deps.yaml
+++ b/.github/workflows/update_deps.yaml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
 jobs:
   update_deps:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/build-linux.yaml
     with:
       GOARCH: amd64


### PR DESCRIPTION
#79 fixed what needed fixing... now this:

https://github.com/fornellas/resonance/actions/runs/10540238106/job/29204674730#step:16:100
```
Pushing pull request branch to 'origin/create-pull-request/patch'
  /usr/bin/git push --force-with-lease origin create-pull-request/patch:refs/heads/create-pull-request/patch
  remote: Permission to fornellas/resonance.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/fornellas/resonance/': The requested URL returned error: 403
  Error: The process '/usr/bin/git' failed with exit code 128
```

🤬 GitHub Actions... guesswork, merge, fail, rinse, repeat and https://noyaml.com/ hell...