### PR TITLE
Fix log indentation

### DIFF
--- a/internal/host/agent_client.go
+++ b/internal/host/agent_client.go
@@ -138,10 +138,7 @@ func copyReader(ctx context.Context, hst host.Host, reader io.Reader, path strin
 }
 
 func NewAgent(ctx context.Context, hst host.Host) (*AgentClient, error) {
-	logger := log.MustLogger(ctx)
-	logger.Info("🐈 Agent")
-
-	ctx, _ = log.MustContextLoggerIndented(ctx)
+	ctx, _ = log.MustContextLoggerSection(ctx, "🐈 Agent")
 
 	agentPath, err := getTmpFile(ctx, hst, "resonance_agent")
 	if err != nil {

--- a/internal/host/cmd_run.go
+++ b/internal/host/cmd_run.go
@@ -33,7 +33,6 @@ func (br cmdHost) Chmod(ctx context.Context, name string, mode os.FileMode) erro
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Chmod", "name", name, "mode", mode)
-	ctx, _ = log.MustContextLoggerIndented(ctx)
 
 	cmd := host.Cmd{
 		Path: "chmod",
@@ -65,7 +64,6 @@ func (br cmdHost) Chown(ctx context.Context, name string, uid, gid int) error {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Chown", "name", name, "uid", uid, "gid", gid)
-	ctx, _ = log.MustContextLoggerIndented(ctx)
 
 	cmd := host.Cmd{
 		Path: "chown",
@@ -97,7 +95,6 @@ func (br cmdHost) Lookup(ctx context.Context, username string) (*user.User, erro
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Lookup", "username", username)
-	ctx, _ = log.MustContextLoggerIndented(ctx)
 
 	cmd := host.Cmd{
 		Path: "cat",
@@ -146,7 +143,6 @@ func (br cmdHost) LookupGroup(ctx context.Context, name string) (*user.Group, er
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("LookupGroup", "name", name)
-	ctx, _ = log.MustContextLoggerIndented(ctx)
 
 	cmd := host.Cmd{
 		Path: "cat",
@@ -213,7 +209,6 @@ func (br cmdHost) Lstat(ctx context.Context, name string) (host.HostFileInfo, er
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Lstat", "name", name)
-	ctx, _ = log.MustContextLoggerIndented(ctx)
 
 	stdout, err := br.stat(ctx, name)
 	if err != nil {
@@ -302,7 +297,6 @@ func (br cmdHost) Mkdir(ctx context.Context, name string, perm os.FileMode) erro
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Mkdir", "name", name, "perm", perm)
-	ctx, _ = log.MustContextLoggerIndented(ctx)
 
 	cmd := host.Cmd{
 		Path: "mkdir",
@@ -335,7 +329,6 @@ func (br cmdHost) ReadFile(ctx context.Context, name string) ([]byte, error) {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("ReadFile", "name", name)
-	ctx, _ = log.MustContextLoggerIndented(ctx)
 
 	cmd := host.Cmd{
 		Path: "cat",
@@ -385,7 +378,6 @@ func (br cmdHost) Remove(ctx context.Context, name string) error {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Remove", "name", name)
-	ctx, _ = log.MustContextLoggerIndented(ctx)
 
 	cmd := host.Cmd{
 		Path: "rm",
@@ -417,7 +409,6 @@ func (br cmdHost) WriteFile(ctx context.Context, name string, data []byte, perm 
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("WriteFile", "name", name, "data", data, "perm", perm)
-	ctx, _ = log.MustContextLoggerIndented(ctx)
 
 	var chmod bool
 	if _, err := br.Lstat(ctx, name); errors.Is(err, os.ErrNotExist) {

--- a/internal/host/ssh.go
+++ b/internal/host/ssh.go
@@ -226,12 +226,15 @@ func NewSsh(
 	port int,
 	timeout time.Duration,
 ) (Ssh, error) {
-	logger := log.MustLogger(ctx)
-	logger.Info(
+	ctx, _ = log.MustContextLoggerSection(
+		ctx,
 		"🖧 SSH",
-		"user", user, "fingerprint", fingerprint, "host", host, "port", port, "timeout", timeout,
+		"user", user,
+		"fingerprint", fingerprint,
+		"host", host,
+		"port", port,
+		"timeout", timeout,
 	)
-	ctx, _ = log.MustContextLoggerIndented(ctx)
 
 	signers, err := sshGetSigners(ctx)
 	if err != nil {

--- a/internal/host/sudo.go
+++ b/internal/host/sudo.go
@@ -125,9 +125,7 @@ type Sudo struct {
 }
 
 func NewSudo(ctx context.Context, hst host.Host) (*Sudo, error) {
-	logger := log.MustLogger(ctx)
-	logger.Info("⚡ Sudo")
-	ctx, _ = log.MustContextLoggerIndented(ctx)
+	ctx, _ = log.MustContextLoggerSection(ctx, "⚡ Sudo")
 
 	sudoHost := Sudo{
 		Host: hst,

--- a/internal/resources/load.go
+++ b/internal/resources/load.go
@@ -18,8 +18,7 @@ import (
 )
 
 func LoadFile(ctx context.Context, path string) (resourcesPkg.Resources, error) {
-	logger := log.MustLogger(ctx).With("path", path)
-	logger.Info("📝 Loading file")
+	_, _ = log.MustContextLoggerSection(ctx, "📝 Loading resources from file", "path", path)
 
 	f, err := os.Open(path)
 	if err != nil {
@@ -88,8 +87,7 @@ func LoadFile(ctx context.Context, path string) (resourcesPkg.Resources, error) 
 }
 
 func LoadDir(ctx context.Context, dir string) (resourcesPkg.Resources, error) {
-	log.MustLogger(ctx).Info("📂 Loading directory", "dir", dir)
-	ctx, logger := log.MustContextLoggerIndented(ctx)
+	ctx, logger := log.MustContextLoggerSection(ctx, "🗃️ Loading resources from directory", "dir", dir)
 
 	resources := resourcesPkg.Resources{}
 
@@ -130,6 +128,7 @@ func LoadDir(ctx context.Context, dir string) (resourcesPkg.Resources, error) {
 
 // Load Resources from path, which can be either a file or a directory.
 func LoadPath(ctx context.Context, path string) (resourcesPkg.Resources, error) {
+	ctx, _ = log.MustContextLoggerSection(ctx, "📂 Loading resources", "path", path)
 	var resources resourcesPkg.Resources
 
 	fileInfo, err := os.Stat(path)

--- a/log/log.go
+++ b/log/log.go
@@ -44,23 +44,21 @@ func MustLogger(ctx context.Context) *slog.Logger {
 	return logger
 }
 
-// Retrieves the logger value from the context, previously set with [WithLogger]. If its handler
-// implements [IndentableHandler], then it WithIndent(), and set the new logger value to a
-// copy of the context. If the handler does not implement [IndentableHandler], return the original
-// context and the retrieved logger.
+// MustContextLoggerSection creates a new log section.
+// It fetches a logger value from the context, previously set with WithLogger, and logs given
+// msg and args as info.
+// If its handler implements [IndentableHandler], then it WithIndent(), and set the new logger value
+// to a copy of the context.
+// If the handler does not implement [IndentableHandler], return the originalcontext and the
+// retrieved logger.
 // It panics if no logger value has been set previously.
-func MustContextLoggerIndented(ctx context.Context) (context.Context, *slog.Logger) {
+func MustContextLoggerSection(ctx context.Context, msg string, args ...any) (context.Context, *slog.Logger) {
 	logger := MustLogger(ctx)
+	logger.Info(msg, args...)
 	handler, ok := logger.Handler().(IndentableHandler)
 	if ok {
 		logger = slog.New(handler.WithIndent())
 		ctx = WithLogger(ctx, logger)
 	}
 	return ctx, logger
-}
-
-// Similar to [MustContextLoggerIndented], but only returns the logger, not the context.
-func MustLoggerIndented(ctx context.Context) *slog.Logger {
-	_, logger := MustContextLoggerIndented(ctx)
-	return logger
 }


### PR DESCRIPTION
The logging handler for console supports indentation, which can be interpreted as a "section".

As of now, indentation can be arbitrarily created, but there's nothing enforcing that ther's any sort of title. This can result in odd outputs.

Eg: instead of :

```
top message
mid message
lower message
```

if nothing is loggen on mid, we end up with:

```
top message
lower message
```

which looks odd. This can happen when for example, mid is only logging on debug, and we're running on info.

This PR (for the most part) addresses that, by changing the interface to "ask for a section title", and enforces the logging of the title as info.

---

**Stack**:
- #95
- #98
- #97
- #96
- #94
- #91
- #90 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*