### PR TITLE
Add stacked PRs support

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -2,7 +2,8 @@ name: pull_request
 on:
   pull_request:
     branches:
-      - '*'
+      - 'master'
+      - 'origin/spr/master/*'
 jobs:
   linux_386:
     uses: ./.github/workflows/build-linux.yaml
@@ -51,3 +52,13 @@ jobs:
       uses: coverallsapp/github-action@v2.3.0
       with:
         parallel-finished: true
+  spr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block PRs against spr/master/*
+        id: check_base
+        run: |
+          if [[ "${{ github.base_ref }}" == origin/spr/master/* ]]; then
+            echo "Base branch seems to be part of a PR stack: this can't be merged directly. Details: https://github.com/ejoffe/spr."
+            exit 1
+          fi

--- a/.spr.yml
+++ b/.spr.yml
@@ -1,0 +1,12 @@
+githubRepoOwner: fornellas
+githubRepoName: resonance
+githubHost: github.com
+githubRemote: origin
+githubBranch: master
+requireChecks: true
+requireApproval: true
+mergeMethod: rebase
+mergeQueue: false
+forceFetchTags: false
+showPrTitlesInStack: false
+branchPushIndividually: false


### PR DESCRIPTION
GitHub is pretty terrible to deal with stacked PRs. I've found https://github.com/ejoffe/spr which seems promissing to help aliviate the pain.

This PR:

- adds the configuration for it (which the CLI creates when we run it)
- sets the pull_request job to run on PRs from spr.
- adds a build signal that fails if the target branch is spr's, to prevent any accidental merge (as spr requires that merges happen from bottom up, always).

commit-id:fc3c74d2

---

**Stack**:
- #95
- #98
- #97
- #96
- #94
- #91
- #90
- #89
- #92 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*