### PR TITLE
Fix pull_request job

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - 'master'
-      - 'origin/spr/master/*'
+      - 'spr/master/*'
 jobs:
   linux_386:
     uses: ./.github/workflows/build-linux.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Block PRs against spr/master/*
         id: check_base
         run: |
-          if [[ "${{ github.base_ref }}" == origin/spr/master/* ]]; then
+          if [[ "${{ github.event.pull_request.base.ref }}" == spr/master/* ]]; then
             echo "Base branch seems to be part of a PR stack: this can't be merged directly. Details: https://github.com/ejoffe/spr."
             exit 1
           fi


### PR DESCRIPTION
The pull request job was not triggered here

https://github.com/fornellas/resonance/pull/90

but sohuld have. The reason is likely the `origin/` prefix that must be dropped (the branch name is actually `spr/master/6b80a22d`, no prefix).

The check to block merges against `spr/master/*` was also broken, attempting to fix it.

---

**Stack**:
- #95
- #98
- #97
- #96
- #94
- #91
- #90
- #89
- #99 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*