### PR TITLE
Drop ad-hoc resource validation on remove=true

### DIFF
--- a/resources/apt_package.go
+++ b/resources/apt_package.go
@@ -31,13 +31,6 @@ func (a *APTPackage) Validate() error {
 		return fmt.Errorf("`package` must match regexp %s: %s", validAptPackageNameRegexp, a.Version)
 	}
 
-	// Remove
-	if a.Remove {
-		if a.Version != "" {
-			return fmt.Errorf("'version' can not be set when 'remove' is true")
-		}
-	}
-
 	// Version
 	// https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
 	if strings.HasSuffix(a.Version, "+") {

--- a/resources/file.go
+++ b/resources/file.go
@@ -40,28 +40,6 @@ func (f *File) Validate() error {
 		return fmt.Errorf("'path' must be absolute")
 	}
 
-	if f.Remove {
-		if f.Content != "" {
-			return fmt.Errorf("'content' can not be set when 'remove' is true")
-		}
-		if f.Perm != os.FileMode(0) {
-			return fmt.Errorf("'perm' can not be set when 'remove' is true")
-		}
-		if f.Uid != 0 {
-			return fmt.Errorf("'uid' can not be set when 'remove' is true")
-		}
-		if f.User != "" {
-			return fmt.Errorf("'user' can not be set when 'remove' is true")
-		}
-		if f.Gid != 0 {
-			return fmt.Errorf("'gid' can not be set when 'remove' is true")
-		}
-		if f.Group != "" {
-			return fmt.Errorf("'group' can not be set when 'remove' is true")
-		}
-		return nil
-	}
-
 	if f.Uid != 0 && f.User != "" {
 		return fmt.Errorf("can't set both 'uid' and 'user'")
 	}


### PR DESCRIPTION
This code is redundant, as we had this logic moved to `resources/resources.go:ValidateResource()`, so it is universally applied to all resource types, no code duplication required.

commit-id:d1ea523e

---

**Stack**:
- #116
- #107
- #108
- #111
- #110
- #109
- #106
- #105
- #104
- #103
- #102
- #101 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*