### PR TITLE
Simplify id & remove resource fields

### DIFF
--- a/resources/apt_package.go
+++ b/resources/apt_package.go
@@ -15,7 +15,7 @@ import (
 // APTPackage manages APT packages.
 type APTPackage struct {
 	// The name of the package
-	Package string `yaml:"package" resonance:"id"`
+	Package string `yaml:"package"`
 	// Whether to remove the package
 	Remove bool `yaml:"remove,omitempty"`
 	// Package version
@@ -27,7 +27,7 @@ var validAptPackageNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9+\-.]{1,}$`)
 
 func (a *APTPackage) Validate() error {
 	// Package
-	if !validAptPackageNameRegexp.MatchString(a.Package) {
+	if !validAptPackageNameRegexp.MatchString(string(a.Package)) {
 		return fmt.Errorf("`package` must match regexp %s: %s", validAptPackageNameRegexp, a.Version)
 	}
 
@@ -41,10 +41,6 @@ func (a *APTPackage) Validate() error {
 	}
 
 	return nil
-}
-
-func (a *APTPackage) Name() string {
-	return a.Package
 }
 
 type APTPackages struct{}
@@ -74,7 +70,7 @@ func (a *APTPackages) Load(ctx context.Context, hst host.Host, resources Resourc
 		Args: []string{"policy"},
 	}
 	for _, aptPackage := range aptPackages {
-		hostCmd.Args = append(hostCmd.Args, aptPackage.Package)
+		hostCmd.Args = append(hostCmd.Args, string(aptPackage.Package))
 	}
 
 	waitStatus, stdout, stderr, err := host.Run(ctx, hst, hostCmd)
@@ -118,7 +114,7 @@ func (a *APTPackages) Load(ctx context.Context, hst host.Host, resources Resourc
 	}
 
 	for _, aptPackage := range aptPackages {
-		installedVersion, ok := pkgInstalledMap[aptPackage.Package]
+		installedVersion, ok := pkgInstalledMap[string(aptPackage.Package)]
 		if !ok {
 			return fmt.Errorf(
 				"failed to get %#v package version: %#v: no version found on output:\n%s",


### PR DESCRIPTION
All resource types must have both an "id" field, that uniquely identifies the resource at a host, and a "remove" field, to inform whether it should be... removed.

As of now, both fields are mandatory, but they can live anywhere in the struct, and the Id field, requires a special tag.

This PR simplifies that, enforcing instead that all resources have the first 2 fields as such:

```go
type Foo struct {
FooName string `yaml:"foo_name"`
Remove bool `yaml:"remove,omitempty"`
}
```

which simplifies things quite a bit.

In particular, when marshaling yamls, the id field will be guaranteed to be the first one, which eases understanding.

---

**Stack**:
- #116
- #107
- #108
- #111
- #110
- #109
- #106
- #105 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*