### PR TITLE
Resources: Add Satisfies

### DIFF
--- a/resources/apt_package.go
+++ b/resources/apt_package.go
@@ -43,6 +43,21 @@ func (a *APTPackage) Validate() error {
 	return nil
 }
 
+func (a *APTPackage) Satisfies(resource Resource) bool {
+	b, ok := resource.(*APTPackage)
+	if !ok {
+		panic("bug: not APTPackage")
+	}
+
+	if a.Version != "" && b.Version == "" {
+		bCopy := *b
+		b = &bCopy
+		b.Version = a.Version
+	}
+
+	return reflect.DeepEqual(a, b)
+}
+
 type APTPackages struct{}
 
 var aptCachePackageRegexp = regexp.MustCompile(`^(.+):$`)

--- a/resources/resources_test.go
+++ b/resources/resources_test.go
@@ -190,6 +190,59 @@ func TestGetResourceRemove(t *testing.T) {
 	require.True(t, GetResourceRemove(resource))
 }
 
+func TestSatisfies(t *testing.T) {
+	require.True(t, Satisfies(
+		&File{
+			Path: "foo",
+		},
+		&File{
+			Path: "foo",
+		},
+	))
+
+	require.False(t, Satisfies(
+		&File{
+			Path: "foo",
+		},
+		&File{
+			Path: "foo",
+			Perm: 0644,
+		},
+	))
+
+	require.True(t, Satisfies(
+		&APTPackage{
+			Version: "1",
+		},
+		&APTPackage{
+			Version: "1",
+		},
+	))
+
+	require.True(t, Satisfies(
+		&APTPackage{
+			Version: "1",
+		},
+		&APTPackage{},
+	))
+
+	require.False(t, Satisfies(
+		&APTPackage{},
+		&APTPackage{
+			Version: "1",
+		},
+	))
+
+	require.False(t, Satisfies(
+		&APTPackage{
+			Version: "1",
+		},
+		&APTPackage{
+			Remove: true,
+		},
+	))
+}
+
 func TestResourceMap(t *testing.T) {
 	file := &File{
 		Path: "/foo",


### PR DESCRIPTION
When comparing some resources, it is not enough to just look "is it the name values". Eg: for a File, if all attributes are the same for 2 resources, then it is the same state. Eg: for APTPackage, if (a) does not require any specific version, but (b) does, then (b) satisfies (a), but (a) does not satisfy (b).

This PR implements this interface, which is required for planning to work.

---

**Stack**:
- #116
- #107
- #108
- #111
- #110
- #109
- #106 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*