### PR TITLE
Add internal/plan

### DIFF
--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -1,0 +1,238 @@
+package plan
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	blueprintPkg "github.com/fornellas/resonance/internal/blueprint"
+	"github.com/fornellas/resonance/internal/diff"
+	resourcesPkg "github.com/fornellas/resonance/resources"
+)
+
+// ResourceDiff holds the diff for applying each Action resource.
+type ResourceDiff struct {
+	// An emoji representing the action
+	Emoji rune
+	// The resource Id
+	Id string
+	// The diff to apply the resource.
+	Chunks diff.Chunks
+}
+
+func (r *ResourceDiff) String() string {
+	return fmt.Sprintf("%c%s", r.Emoji, r.Id)
+}
+
+// NewResourceDiff creates a new ResourceDiff
+func NewResourceDiff(emoji rune, planResource resourcesPkg.Resource, chunks diff.Chunks) *ResourceDiff {
+	return &ResourceDiff{
+		Emoji:  emoji,
+		Id:     resourcesPkg.GetResourceId(planResource),
+		Chunks: chunks,
+	}
+}
+
+// Action holds actions required to apply, calculated from a Step.
+type Action struct {
+	// A string with the resource type (eg: File, APTPackage)
+	ResourceType string
+	// The calculated diff for each Step resource when applying it.
+	ResourceDiffs []*ResourceDiff
+	// The resources that needs to be applied for the Step (eg: if no changes required for the
+	// resource, it won't be here)
+	ApplyResources resourcesPkg.Resources
+}
+
+// NewAction creates a new Action for a given Step, calculating required changes as a function
+// of the before (apply) state of the step resources.
+func NewAction(step *blueprintPkg.Step, beforeResourceMap resourcesPkg.ResourceMap) *Action {
+	action := &Action{
+		ResourceType:   step.Type(),
+		ResourceDiffs:  make([]*ResourceDiff, len(step.Resources())),
+		ApplyResources: resourcesPkg.Resources{},
+	}
+	for j, planResource := range step.Resources() {
+		beforeResource := beforeResourceMap.GetResourceWithSameTypeId(planResource)
+		if beforeResource == nil {
+			panic("bug: before resource not found")
+		}
+		var resourceAction *ResourceDiff = nil
+		if resourcesPkg.Satisfies(beforeResource, planResource) {
+			resourceAction = NewResourceDiff('✅', planResource, nil)
+		} else {
+			action.ApplyResources = append(action.ApplyResources, planResource)
+			var emoji rune
+			if resourcesPkg.GetResourceAbsent(beforeResource) {
+				emoji = '🔧'
+			} else {
+				if resourcesPkg.GetResourceAbsent(planResource) {
+					emoji = '🗑'
+				} else {
+					emoji = '🔄'
+				}
+			}
+			resourceAction = NewResourceDiff(emoji, planResource, diff.DiffAsYaml(
+				beforeResource, planResource,
+			))
+		}
+		action.ResourceDiffs[j] = resourceAction
+	}
+	slices.SortFunc(action.ResourceDiffs, func(a, b *ResourceDiff) int {
+		return strings.Compare(a.Id, b.Id)
+	})
+	slices.SortFunc(action.ApplyResources, func(a, b resourcesPkg.Resource) int {
+		return strings.Compare(resourcesPkg.GetResourceId(a), resourcesPkg.GetResourceId(b))
+	})
+	return action
+}
+
+// String returns a single-line representation of the action.
+func (a *Action) String() string {
+	actionStrs := make([]string, len(a.ResourceDiffs))
+	for i, resourceDiffs := range a.ResourceDiffs {
+		actionStrs[i] = resourceDiffs.String()
+	}
+	return fmt.Sprintf("%s:%s", a.ResourceType, strings.Join(actionStrs, ","))
+}
+
+// DiffString returns details on the diff required to apply this action.
+func (a *Action) DiffString() string {
+	var buff bytes.Buffer
+
+	if len(a.ResourceDiffs) == 1 {
+		resourceDiffs := a.ResourceDiffs[0]
+		if len(resourceDiffs.Chunks) > 0 {
+			fmt.Fprintf(&buff, "%s", resourceDiffs.Chunks.String())
+		}
+	} else {
+		for _, resourceDiffs := range a.ResourceDiffs {
+			if len(resourceDiffs.Chunks) > 0 {
+				fmt.Fprintf(&buff, "%s:\n", resourceDiffs.Id)
+				fmt.Fprintf(&buff, "  %s\n",
+					strings.Join(
+						strings.Split(
+							strings.TrimSuffix(resourceDiffs.Chunks.String(), "\n"),
+							"\n",
+						),
+						"\n  ",
+					),
+				)
+			}
+		}
+	}
+
+	return strings.TrimSuffix(buff.String(), "\n")
+}
+
+// DetailedString returns a multi-line string, fully describing the action and its diff.
+func (a *Action) DetailedString() string {
+	diffStr := a.DiffString()
+	if len(diffStr) > 0 {
+		return strings.TrimSuffix(
+			fmt.Sprintf("%s\n  %s\n",
+				a,
+				strings.Join(
+					strings.Split(
+						strings.TrimSuffix(diffStr, "\n"),
+						"\n",
+					),
+					"\n  ",
+				),
+			),
+			"\n",
+		)
+	} else {
+		return a.String()
+	}
+}
+
+// Plan holds all actions required to apply changes to a host.
+// This enables evaluating all changes before they are applied.
+type Plan []*Action
+
+// NewPlan crafts a new plan as a function of: the delined target state, the last state (how the
+// host is at the moment) and the original state of any managed resource.
+func NewPlan(
+	ctx context.Context,
+	targetBlueprint, lastBlueprint *blueprintPkg.Blueprint,
+	loadOriginalResource func(ctx context.Context, resource resourcesPkg.Resource) (resourcesPkg.Resource, error),
+) (Plan, error) {
+	targetResources := targetBlueprint.Resources()
+	planResources := make(resourcesPkg.Resources, len(targetResources))
+	beforeResources := make(resourcesPkg.Resources, len(targetResources))
+
+	// Add every target resource to plan
+	for i, targetResource := range targetResources {
+		planResources[i] = targetResource
+		// Before resource is a function of last resource existing or not
+		lastResource := lastBlueprint.GetResourceWithSameTypeId(targetResource)
+		if lastResource == nil {
+			originalResource, err := loadOriginalResource(ctx, targetResource)
+			if err != nil {
+				return nil, err
+			}
+			beforeResources[i] = originalResource
+		} else {
+			beforeResources[i] = lastResource
+		}
+	}
+
+	// each last resource that is not on target must be restored to original
+	type ToOriginal struct {
+		lastIdx  int
+		resource resourcesPkg.Resource
+	}
+	toOriginalSlice := []ToOriginal{}
+	lastResources := lastBlueprint.Resources()
+	for i, lastResource := range lastResources {
+		if targetBlueprint.HasResourceWithSameTypeId(lastResource) {
+			continue
+		}
+		originalResource, err := loadOriginalResource(ctx, lastResource)
+		if err != nil {
+			return nil, err
+		}
+		toOriginalSlice = append(toOriginalSlice, ToOriginal{
+			lastIdx:  i,
+			resource: originalResource,
+		})
+		beforeResources = append(beforeResources, lastResource)
+	}
+
+	// merge original resources with plan resources, respecting the original order
+	for _, toOriginal := range toOriginalSlice {
+		idx := -1
+		for i := toOriginal.lastIdx + 1; i < len(lastResources) && idx < 0; i++ {
+			lastResourceTypeId := resourcesPkg.GetResourceTypeId(lastResources[i])
+			for j, planResource := range planResources {
+				planResourceTypeId := resourcesPkg.GetResourceTypeId(planResource)
+				if planResourceTypeId == lastResourceTypeId {
+					idx = j
+					break
+				}
+			}
+		}
+		if idx < 0 {
+			idx = len(planResources)
+		}
+		planResources = append(
+			planResources[:idx],
+			append(resourcesPkg.Resources{toOriginal.resource}, planResources[idx:]...)...,
+		)
+	}
+
+	// Calculate plan actions
+	planBlueprint, err := blueprintPkg.NewBlueprintFromResources(ctx, planResources)
+	if err != nil {
+		return nil, err
+	}
+	beforeResourceMap := resourcesPkg.NewResourceMap(beforeResources)
+	plan := make(Plan, len(planBlueprint.Steps))
+	for i, step := range planBlueprint.Steps {
+		plan[i] = NewAction(step, beforeResourceMap)
+	}
+	return plan, nil
+}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1,0 +1,303 @@
+package plan
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	blueprintPkg "github.com/fornellas/resonance/internal/blueprint"
+	"github.com/fornellas/resonance/log"
+	resourcesPkg "github.com/fornellas/resonance/resources"
+)
+
+func TestPlan(t *testing.T) {
+	ctx := context.Background()
+	ctx = log.WithTestLogger(ctx)
+
+	type testCase struct {
+		name              string
+		targetResources   resourcesPkg.Resources
+		lastResources     resourcesPkg.Resources
+		originalResources resourcesPkg.Resources
+		expectedPlan      string
+	}
+
+	// These test cases go over various combinations of the resource existing
+	// or not existing on the target / last blueprints, their states and
+	// the original state.
+	// Expectations are a function of the planned actions and the diff generated.
+	testCases := []testCase{
+		{
+			name: "target=exists,last=absent,original=absent",
+			targetResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "target",
+				},
+			},
+			lastResources: resourcesPkg.Resources{},
+			originalResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:   "/foo",
+					Absent: true,
+				},
+			},
+			expectedPlan: `File:🔧/foo
+  path: /foo
+  -absent: true
+  +content: target`,
+		},
+		{
+			name: "target!=original,last=absent,original=exists",
+			targetResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "target",
+				},
+			},
+			lastResources: resourcesPkg.Resources{},
+			originalResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "original",
+				},
+			},
+			expectedPlan: `File:🔄/foo
+  path: /foo
+  -content: original
+  +content: target`,
+		},
+		{
+			name: "target=original,last=absent,original=exists",
+			targetResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "original",
+				},
+			},
+			lastResources: resourcesPkg.Resources{},
+			originalResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "original",
+				},
+			},
+			expectedPlan: `File:✅/foo`,
+		},
+		{
+			name:            "target=absent,last=exists,original=exists",
+			targetResources: resourcesPkg.Resources{},
+			lastResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "last",
+				},
+			},
+			originalResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "original",
+				},
+			},
+			expectedPlan: `File:🔄/foo
+  path: /foo
+  -content: last
+  +content: original`,
+		},
+		{
+			name: "target=last,last=exists,original=exists",
+			targetResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "last",
+				},
+			},
+			lastResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "last",
+				},
+			},
+			originalResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "original",
+				},
+			},
+			expectedPlan: `File:✅/foo`,
+		},
+		{
+			name: "target=!last,last=exists,original=exists",
+			targetResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "target",
+				},
+			},
+			lastResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "last",
+				},
+			},
+			originalResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "original",
+				},
+			},
+			expectedPlan: `File:🔄/foo
+  path: /foo
+  -content: last
+  +content: target`,
+		},
+		{
+			name: "target=absent,last=exists,original=exists",
+			targetResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:   "/foo",
+					Absent: true,
+				},
+			},
+			lastResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "last",
+				},
+			},
+			originalResources: resourcesPkg.Resources{
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "original",
+				},
+			},
+			expectedPlan: `File:🗑/foo
+  path: /foo
+  -content: last
+  +absent: true`,
+		},
+		{
+			name: "GroupResource+SingleResource",
+			targetResources: resourcesPkg.Resources{
+				&resourcesPkg.APTPackage{
+					Package: "barPkg",
+					Version: "3.5.target",
+				},
+				&resourcesPkg.File{
+					Path:    "/baz",
+					Content: "target",
+				},
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "target",
+				},
+			},
+			lastResources: resourcesPkg.Resources{
+				&resourcesPkg.APTPackage{
+					Package: "barPkg",
+					Version: "3.4.last",
+				},
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "last",
+				},
+				&resourcesPkg.APTPackage{
+					Package: "fooPkg",
+					Version: "1.2.last",
+				},
+				&resourcesPkg.File{
+					Path:    "/bar",
+					Content: "last",
+				},
+			},
+			originalResources: resourcesPkg.Resources{
+				&resourcesPkg.APTPackage{
+					Package: "barPkg",
+					Version: "3.4.original",
+				},
+				&resourcesPkg.File{
+					Path:    "/foo",
+					Content: "original",
+				},
+				&resourcesPkg.APTPackage{
+					Package: "fooPkg",
+					Version: "1.2.original",
+				},
+				&resourcesPkg.File{
+					Path:    "/bar",
+					Content: "original",
+				},
+				&resourcesPkg.File{
+					Path:    "/baz",
+					Content: "original",
+				},
+			},
+			expectedPlan: `APTPackages:🔄barPkg,🔄fooPkg
+  barPkg:
+    package: barPkg
+    -version: 3.4.last
+    +version: 3.5.target
+  fooPkg:
+    package: fooPkg
+    -version: 1.2.last
+    +version: 1.2.original
+File:🔄/baz
+  path: /baz
+  -content: original
+  +content: target
+File:🔄/foo
+  path: /foo
+  -content: last
+  +content: target
+File:🔄/bar
+  path: /bar
+  -content: last
+  +content: original`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			targetBlueprint, err := blueprintPkg.NewBlueprintFromResources(ctx, tc.targetResources)
+			require.NoError(t, err)
+
+			lastBlueprint, err := blueprintPkg.NewBlueprintFromResources(ctx, tc.lastResources)
+			require.NoError(t, err)
+
+			originalResourceMap := resourcesPkg.NewResourceMap(tc.originalResources)
+
+			plan, err := NewPlan(
+				ctx,
+				targetBlueprint, lastBlueprint,
+				func(ctx context.Context, resource resourcesPkg.Resource) (resourcesPkg.Resource, error) {
+					return originalResourceMap.GetResourceWithSameTypeId(resource), nil
+				},
+			)
+			require.NoError(t, err)
+
+			require.GreaterOrEqual(t, len(plan), len(targetBlueprint.Steps))
+
+			var buff bytes.Buffer
+			for _, action := range plan {
+				fmt.Fprintf(&buff, "%s\n", action.DetailedString())
+				idsWithDiff := []string{}
+				for _, resourceDiff := range action.ResourceDiffs {
+					if len(resourceDiff.Chunks) > 0 {
+						idsWithDiff = append(idsWithDiff, resourceDiff.Id)
+					}
+				}
+				applyIds := []string{}
+				for _, applyResource := range action.ApplyResources {
+					applyIds = append(applyIds, resourcesPkg.GetResourceId(applyResource))
+				}
+				require.Equal(t, idsWithDiff, applyIds)
+			}
+			planStr := strings.TrimSuffix(buff.String(), "\n")
+			require.Equal(t, tc.expectedPlan, planStr)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the inner mechanics of planning changes. A follow up PR will deal with its inputs:

- The original version of resources.
- The last applied version of resources.
- The target resources.

As a function of these, diffirent things must happen when applying:

- If resource exist on target, but not on last, apply target (over original).
- If resource does not exist on target, but exist on last, apply original (stop managing it).
- If resource exist in target and on last, apply target (over last).

In terms of actions:

- If no change required (following #106 rules), ✅ no action, no diff.
- If changes required, and coming from absent to present, 🔧 create action, with diff from `nil` to target.
- If changes required, and coming from present to absent, 🗑 remove action, diff from previous state (either original or last) to `nil`.
- If changes required, and coming from present to also present, 🔄 update action, diff from previous state (either original or last) to target.

---

**Stack**:
- #116
- #107
- #108 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*