### PR TITLE
Change 'remove' to 'absent'

### DIFF
--- a/resources/apt_package.go
+++ b/resources/apt_package.go
@@ -17,7 +17,7 @@ type APTPackage struct {
 	// The name of the package
 	Package string `yaml:"package"`
 	// Whether to remove the package
-	Remove bool `yaml:"remove,omitempty"`
+	Absent bool `yaml:"absent,omitempty"`
 	// Package version
 	Version string `yaml:"version,omitempty"`
 }
@@ -138,7 +138,7 @@ func (a *APTPackages) Load(ctx context.Context, hst host.Host, resources Resourc
 		}
 
 		if installedVersion == "(none)" {
-			aptPackage.Remove = true
+			aptPackage.Absent = true
 		} else {
 			aptPackage.Version = installedVersion
 		}
@@ -158,7 +158,7 @@ func (a *APTPackages) Apply(ctx context.Context, hst host.Host, resources Resour
 	pkgArgs := make([]string, len(aptPackages))
 	for i, aptPackage := range aptPackages {
 		var pkgArg string
-		if aptPackage.Remove {
+		if aptPackage.Absent {
 			pkgArg = fmt.Sprintf("%s-", aptPackage.Package)
 		} else {
 			pkgArg = fmt.Sprintf("%s=%s", aptPackage.Package, aptPackage.Version)

--- a/resources/file.go
+++ b/resources/file.go
@@ -16,7 +16,7 @@ type File struct {
 	// Path is the absolute path to the file
 	Path string `yaml:"path"`
 	// Whether to remove the file
-	Remove bool `yaml:"remove,omitempty"`
+	Absent bool `yaml:"absent,omitempty"`
 	// Contents of the file
 	Content string `yaml:"content,omitempty"`
 	// File permissions
@@ -60,7 +60,7 @@ func (f *File) Load(ctx context.Context, hst host.Host) error {
 	content, err := hst.ReadFile(ctx, string(f.Path))
 	if err != nil {
 		if os.IsNotExist(err) {
-			f.Remove = true
+			f.Absent = true
 			return nil
 		}
 		return err
@@ -117,7 +117,7 @@ func (f *File) Resolve(ctx context.Context, hst host.Host) error {
 
 func (f *File) Apply(ctx context.Context, hst host.Host) error {
 	// Remove
-	if f.Remove {
+	if f.Absent {
 		err := hst.Remove(ctx, string(f.Path))
 		if os.IsNotExist(err) {
 			return nil

--- a/resources/resources_test.go
+++ b/resources/resources_test.go
@@ -28,13 +28,13 @@ func TestValidateResource(t *testing.T) {
 			errorContains: "resource id field \"path\" must be set",
 		},
 		{
-			name: "remove with other fields set",
+			name: "absent with other fields set",
 			resource: &File{
 				Path:   "/tmp/foo",
+				Absent: true,
 				Perm:   0644,
-				Remove: true,
 			},
-			errorContains: "resource has remove set to true, but other fields are set",
+			errorContains: "resource has absent set to true, but other fields are set",
 		},
 		{
 			name: "invalid state",
@@ -173,21 +173,21 @@ func TestNewResourceWithSameId(t *testing.T) {
 	}
 }
 
-func TestSetResourceRemove(t *testing.T) {
+func TestSetResourceAbsent(t *testing.T) {
 	resource := &File{
 		Path: "/tmp/foo",
 	}
-	SetResourceRemove(resource)
-	require.True(t, resource.Remove)
+	SetResourceAbsent(resource)
+	require.True(t, resource.Absent)
 }
 
-func TestGetResourceRemove(t *testing.T) {
+func TestGetResourceAbsent(t *testing.T) {
 	resource := &File{
 		Path: "/tmp/foo",
 	}
-	require.False(t, GetResourceRemove(resource))
-	resource.Remove = true
-	require.True(t, GetResourceRemove(resource))
+	require.False(t, GetResourceAbsent(resource))
+	resource.Absent = true
+	require.True(t, GetResourceAbsent(resource))
 }
 
 func TestSatisfies(t *testing.T) {
@@ -238,7 +238,7 @@ func TestSatisfies(t *testing.T) {
 			Version: "1",
 		},
 		&APTPackage{
-			Remove: true,
+			Absent: true,
 		},
 	))
 }


### PR DESCRIPTION
Resources must have a field to indicate whether it is there or not. Until now, the word 'remove' has been used. When implementing the plan mechanics, I figured that this term can create confusion in some circunstances.

This PR changes the name 'remove' to 'absent', which when true, indicates... the resource is absent.

---

**Stack**:
- #116
- #107
- #108
- #111
- #110
- #109 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*