### PR TITLE
Add apply command

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	blueprintPkg "github.com/fornellas/resonance/internal/blueprint"
+	planPkg "github.com/fornellas/resonance/internal/plan"
+	iResouresPkg "github.com/fornellas/resonance/internal/resources"
+	"github.com/fornellas/resonance/log"
+	resouresPkg "github.com/fornellas/resonance/resources"
+)
+
+var ApplyCmd = &cobra.Command{
+	Use:   "apply [flags] [file|dir]",
+	Short: "Apply resources.",
+	Long:  "Load resources from file/dir and apply them.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		path := args[0]
+
+		ctx := cmd.Context()
+
+		logger := log.MustLogger(ctx)
+
+		logger.Info("✏️ Applying", "path", path)
+
+		host, err := GetHost(ctx)
+		if err != nil {
+			logger.Error(err.Error())
+			Exit(1)
+		}
+		defer host.Close()
+		logger.Info("🖥️ Target", "host", host)
+
+		store := GetStore(host)
+
+		var targetResources resouresPkg.Resources
+		{
+			var err error
+			ctx, _ := log.MustContextLoggerSection(ctx, "📂 Loading target resources")
+			targetResources, err = iResouresPkg.LoadPath(ctx, path)
+			if err != nil {
+				logger.Error(err.Error())
+				Exit(1)
+			}
+			_, logger := log.MustContextLoggerSection(ctx, "📚 All loaded resources")
+			for _, resource := range targetResources {
+				logger.Info(resouresPkg.GetResourceTypeName(resource), "yaml", resouresPkg.GetResourceYaml(resource))
+			}
+		}
+
+		var plan planPkg.Plan
+		var targetBlueprint *blueprintPkg.Blueprint
+		var lastBlueprint *blueprintPkg.Blueprint
+		{
+			ctx, logger := log.MustContextLoggerSection(ctx, "📝 Planning")
+			plan, targetBlueprint, lastBlueprint, err = planPkg.PrepAndPlan(ctx, host, store, targetResources)
+			if err != nil {
+				logger.Error(err.Error())
+				Exit(1)
+			}
+			{
+				ctx, _ := log.MustContextLoggerSection(ctx, "💾 Saving tatrget Blueprint")
+				hasTargetBlueprint, err := store.HasTargetBlueprint(ctx)
+				if err != nil {
+					logger.Error(err.Error())
+					Exit(1)
+				}
+				if hasTargetBlueprint {
+					logger.Error("a previous apply was interrupted")
+					Exit(1)
+				} else {
+					if err := store.SaveTargetBlueprint(ctx, targetBlueprint); err != nil {
+						logger.Error(err.Error())
+						Exit(1)
+					}
+				}
+			}
+		}
+
+		if err := plan.Apply(ctx, host); err != nil {
+			logger.Error(err.Error())
+			Exit(1)
+		}
+
+		{
+			ctx, logger := log.MustContextLoggerSection(ctx, "🧹 State cleanup")
+
+			targetResourcesMap := resouresPkg.NewResourceMap(targetResources)
+			for _, lastResource := range lastBlueprint.Resources() {
+				if !targetResourcesMap.HasResourceWithSameTypeId(lastResource) {
+					if err := store.DeleteOriginalResource(ctx, lastResource); err != nil {
+						logger.Error(err.Error())
+						Exit(1)
+					}
+				}
+			}
+
+			if err := store.SaveLastBlueprint(ctx, targetBlueprint); err != nil {
+				logger.Error(err.Error())
+				Exit(1)
+			}
+
+			if err := store.DeleteTargetBlueprint(ctx); err != nil {
+				logger.Error(err.Error())
+				Exit(1)
+			}
+		}
+
+		logger.Info("🎆 Apply successful")
+	},
+}
+
+func init() {
+	AddHostFlags(ApplyCmd)
+
+	AddStoreFlags(ApplyCmd)
+
+	RootCmd.AddCommand(ApplyCmd)
+}

--- a/cmd/apply_linux_test.go
+++ b/cmd/apply_linux_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	resouresPkg "github.com/fornellas/resonance/resources"
+)
+
+func TestApply(t *testing.T) {
+	tempDir := t.TempDir()
+	storeDir := filepath.Join(tempDir, "store")
+	resourcesDir := filepath.Join(tempDir, "resources")
+	resourcesFile := filepath.Join(resourcesDir, "resources.yaml")
+	filesDir := filepath.Join(tempDir, "files")
+	err := os.MkdirAll(filesDir, fs.FileMode(0755))
+	require.NoError(t, err)
+	fileContent := "bar"
+
+	resources := resouresPkg.Resources{
+		&resouresPkg.File{
+			Path:    filepath.Join(filesDir, "bar"),
+			Perm:    os.FileMode(0644),
+			Content: fileContent,
+			Uid:     uint32(os.Geteuid()),
+			Gid:     uint32(os.Getgid()),
+		},
+	}
+
+	WriteResourcesFile(t, resourcesFile, resources)
+
+	t.Run("first apply", func(t *testing.T) {
+		(&TestCmd{
+			Args: []string{
+				"apply",
+				"--target-localhost",
+				"--store", "localhost",
+				"--store-localhost-path", storeDir,
+				resourcesDir,
+			},
+			ExpectStderrContains: []string{fmt.Sprintf(`⚙️ Applying
+  File:🔧%s/bar
+    diff:
+      path: %s/bar
+      -absent: true
+      +content: bar
+      +perm: 420
+      +uid: 1000
+      +gid: 1000
+🧹 State cleanup`,
+				filesDir, filesDir,
+			)},
+		}).Run(t)
+	})
+
+	t.Run("re-apply", func(t *testing.T) {
+		(&TestCmd{
+			Args: []string{
+				"apply",
+				"--target-localhost",
+				"--store", "localhost",
+				"--store-localhost-path", storeDir,
+				resourcesDir,
+			},
+			ExpectStderrContains: []string{fmt.Sprintf(`⚙️ Applying
+  File:✅%s/bar
+🧹 State cleanup`,
+				filesDir,
+			)},
+		}).Run(t)
+	})
+}

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -330,6 +330,10 @@ func (m ResourceMap) GetResourceWithSameTypeId(resource Resource) Resource {
 	return r
 }
 
+func (m ResourceMap) HasResourceWithSameTypeId(resource Resource) bool {
+	return m.GetResourceWithSameTypeId(resource) != nil
+}
+
 type Resources []Resource
 
 func (r Resources) Ids() string {


### PR DESCRIPTION
Follow up to #107 (which added the `plan` command). Now we're _finally_ at the point where things are starting to be functional & testable.

Once this PR merges, we should have all the basic inner workings to calculate all changes, plan and apply them, including all state management (eg: to allow restoring to the original state when we no longer manage a resource).

Getting closer to the first worknig alpha release!

Closes #53.