### PR TITLE
Add update-deps make target

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -48,14 +48,10 @@ jobs:
           key: linux-${{ inputs.GOARCH }}-${{ hashFiles('**/go.sum', '**/*.go') }}
           restore-keys: linux-${{ inputs.GOARCH }}-
       # Update Deps
-      - name: Update Go
+      - name: Update Deps
         if: ${{ inputs.update-deps == true }}
         run: |
-          ./build.sh go-update
-      - name: Update Go Dependencies
-        if: ${{ inputs.update-deps == true }}
-        run: |
-          ./build.sh go-get-u-t
+          ./build.sh update-deps
       # Update Deps
       - name: Diff
         if: ${{ inputs.update-deps == true }}

--- a/Makefile
+++ b/Makefile
@@ -346,12 +346,14 @@ go-update: go
 	set -e
 	set -o pipefail
 	$(GO) mod edit -go $$(curl -s https://go.dev/VERSION?m=text | head -n 1 | cut -c 3-)
+update-deps: go-update
 
 # go get -u
 
 .PHONY: go-get-u-t
 go-get-u-t: go go-mod-tidy
 	$(GO) get -u ./...
+update-deps: go-get-u-t
 
 ##
 ## Test
@@ -521,6 +523,18 @@ ci-dev:
 		GO_TEST_NO_COVER=1 \
 		GO_TEST_BUILD_FLAGS_NO_RACE=1 \
 		GO_BUILD_AGENT_NATIVE_ONLY=1
+
+##
+## update
+##
+
+.PHONY: update-deps-help
+update-deps-help:
+	@echo 'update-deps: Update all dependencies'
+help: update-deps-help
+
+.PHONY: update-deps
+update-deps:
 
 ##
 ## rrb


### PR DESCRIPTION
This PR adds a `update-deps` Makefile target, to simplify the interface of updatting things.

This will be useful on #75, which now requires [an ad-hoc version on the Makefile](https://github.com/fornellas/resonance/pull/75/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R200).