### PR TITLE
Fix rrb-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,8 +559,9 @@ rrb: go
 
 .PHONY: rrb-dev
 rrb-dev:
-	$(MAKE) $(MFLAGS) MAKELEVEL= ci \
-		rrb RRB_MAKE_TARGET=ci-dev
+	$(MAKE) $(MFLAGS) MAKELEVEL= \
+		rrb \
+			RRB_MAKE_TARGET=ci-dev
 
 endif
 


### PR DESCRIPTION
We had a stray `ci` target there... let's get rid of it. It was just making the first build super slow, for no benefit.