### PR TITLE
Move grpc agent to its "final" dentination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@
 /cover.txt
 /internal/.git-toplevel
 /internal/.version
-/internal/grpc/proto/*.pb.go
-/internal/host/agent_server_http_linux_*_gz.go
+/internal/host/agent_server_grpc/proto/*.pb.go
+/internal/host/agent_server_grpc/server/server.*.*
+/internal/host/agent_server_grpc/client/client.*.*
 /internal/host/agent_server_http/agent_server_http_linux_*
 /internal/host/agent_server_http/agent_server_http_linux_*.gz
+/internal/host/agent_server_http_linux_*_gz.go
 /resonance.*.*

--- a/internal/host/agent_server_grpc/client/main.go
+++ b/internal/host/agent_server_grpc/client/main.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/fornellas/resonance/internal/grpc/proto"
+	"github.com/fornellas/resonance/internal/host/agent_server_grpc/proto"
 )
 
 func main() {

--- a/internal/host/agent_server_grpc/proto/service.proto
+++ b/internal/host/agent_server_grpc/proto/service.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/fornellas/resonance/internal/grpc/proto";
+option go_package = "github.com/fornellas/resonance/internal/host/agent_server_grpc/proto";
 
 package resonance;
 

--- a/internal/host/agent_server_grpc/server/main.go
+++ b/internal/host/agent_server_grpc/server/main.go
@@ -9,7 +9,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/fornellas/resonance/internal/grpc/proto"
+	"github.com/fornellas/resonance/internal/host/agent_server_grpc/proto"
 )
 
 type commandServiceServer struct {


### PR DESCRIPTION
Mostly just moving the test grpc agent from #75 to a place that matches the HTTP agent placement.

Bonus:

- Call go build to both client & server, so we can actually easily bulid & manually test them.
- Fix a bug with `RRB_IGNORE_PATTERN` not ignoring generated `.go` files, so RRB would just re-trigger itself and never finish.

commit-id:b4b6383b

---

**Stack**:
- #116
- #107
- #108
- #111
- #110
- #109
- #106
- #105
- #104
- #103
- #102
- #101
- #130
- #126 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*