### PR TITLE
Add os & arch to version

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	_ "embed"
+	"fmt"
+	"runtime"
 	"strings"
 )
 
@@ -12,5 +14,9 @@ import (
 var Version string
 
 func init() {
-	Version = strings.TrimSuffix(Version, "\n")
+	Version = fmt.Sprintf(
+		"%s.%s.%s",
+		strings.TrimSuffix(Version, "\n"),
+		runtime.GOOS, runtime.GOARCH,
+	)
 }


### PR DESCRIPTION
ATM we only have the git tag in the version, let's add GOOS and GOARCH as well, which can be useful in the future.