### PR TITLE
Fix build: (fully remove arm 32bit)

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,12 +15,6 @@ jobs:
     with:
       GOARCH: amd64
     secrets: inherit
-  # disabled because arm is not supported by protobuf
-  # linux_arm:
-  #   uses: ./.github/workflows/build-linux.yaml
-  #   with:
-  #     GOARCH: arm
-  #   secrets: inherit
   linux_arm64:
     uses: ./.github/workflows/build-linux.yaml
     with:
@@ -42,7 +36,6 @@ jobs:
     needs:
       - linux_386
       - linux_amd64
-      - linux_arm
       - linux_arm64
       - darwin_amd64
       - darwin_arm64

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,13 +18,6 @@ jobs:
       upload-artifact: ${{ startsWith(github.ref, 'refs/tags/') }}
       GOARCH: amd64
     secrets: inherit
-  # disabled because arm is not supported by protobuf
-  # linux_arm:
-  #   uses: ./.github/workflows/build-linux.yaml
-  #   with:
-  #     upload-artifact: ${{ startsWith(github.ref, 'refs/tags/') }}
-  #     GOARCH: arm
-  #   secrets: inherit
   linux_arm64:
     uses: ./.github/workflows/build-linux.yaml
     with:
@@ -54,7 +47,6 @@ jobs:
     needs:
       - linux_386
       - linux_amd64
-      - linux_arm
       - linux_arm64
       - darwin_amd64
       - darwin_arm64
@@ -65,9 +57,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: ${{ needs.linux_amd64.outputs.artifact }}
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.linux_arm.outputs.artifact }}
       - uses: actions/download-artifact@v3
         with:
           name: ${{ needs.linux_arm64.outputs.artifact }}
@@ -83,7 +72,6 @@ jobs:
           files: |
             ${{ needs.linux_386.outputs.artifact }}
             ${{ needs.linux_amd64.outputs.artifact }}
-            ${{ needs.linux_arm.outputs.artifact }}
             ${{ needs.linux_arm64.outputs.artifact }}
             ${{ needs.darwin_amd64.outputs.artifact }}
             ${{ needs.darwin_arm64.outputs.artifact }}
@@ -97,7 +85,6 @@ jobs:
     needs:
       - linux_386
       - linux_amd64
-      - linux_arm
       - linux_arm64
       - darwin_amd64
       - darwin_arm64


### PR DESCRIPTION
On #75 we dropped arm 32bit support (we'll decide on https://github.com/fornellas/resonance/issues/124 what to do about it). There was left over references, which are [breaknig the build](https://github.com/fornellas/resonance/actions/runs/10646571228):

```
The workflow is not valid. .github/workflows/push.yaml (Line: 57, Col: 9): Job 'release' depends on unknown job 'linux_arm'. .github/workflows/push.yaml (Line: 100, Col: 9): Job 'coveralls' depends on unknown job 'linux_arm'.
```

This PR fixes that, by erasing all arm 32 references.

---

**Stack**:
- #116
- #107
- #108
- #111
- #110
- #109
- #106
- #105
- #104
- #103
- #102
- #101
- #130
- #126
- #129 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*