### PR TITLE
Fix console logger indentation for level > info

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -55,10 +55,12 @@ func MustLogger(ctx context.Context) *slog.Logger {
 func MustContextLoggerSection(ctx context.Context, msg string, args ...any) (context.Context, *slog.Logger) {
 	logger := MustLogger(ctx)
 	logger.Info(msg, args...)
-	handler, ok := logger.Handler().(IndentableHandler)
-	if ok {
-		logger = slog.New(handler.WithIndent())
-		ctx = WithLogger(ctx, logger)
+	if logger.Handler().Enabled(ctx, slog.LevelInfo) {
+		handler, ok := logger.Handler().(IndentableHandler)
+		if ok {
+			logger = slog.New(handler.WithIndent())
+			ctx = WithLogger(ctx, logger)
+		}
 	}
 	return ctx, logger
 }


### PR DESCRIPTION
PR #90 introduced sections and logs as info when a new section is created. However, if the log level is higher (eg: warn), then the section won't be logged, and any higher level log (eg: warn, error) will be indented without a section.

This PR fixes that, by only enabling indentation when the level info is enabled.

commit-id:f7c2cc66

---

**Stack**:
- #116
- #107
- #108
- #111
- #110
- #109
- #106
- #105
- #104
- #103
- #102
- #101
- #130 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*