### PR TITLE
Fix apply tests

### DIFF
--- a/cmd/apply_linux_test.go
+++ b/cmd/apply_linux_test.go
@@ -21,14 +21,16 @@ func TestApply(t *testing.T) {
 	err := os.MkdirAll(filesDir, fs.FileMode(0755))
 	require.NoError(t, err)
 	fileContent := "bar"
+	fileUid := uint32(os.Geteuid())
+	fileGid := uint32(os.Getgid())
 
 	resources := resouresPkg.Resources{
 		&resouresPkg.File{
 			Path:    filepath.Join(filesDir, "bar"),
 			Perm:    os.FileMode(0644),
 			Content: fileContent,
-			Uid:     uint32(os.Geteuid()),
-			Gid:     uint32(os.Getgid()),
+			Uid:     fileUid,
+			Gid:     fileGid,
 		},
 	}
 
@@ -50,10 +52,10 @@ func TestApply(t *testing.T) {
       -absent: true
       +content: bar
       +perm: 420
-      +uid: 1000
-      +gid: 1000
+      +uid: %d
+      +gid: %d
 🧹 State cleanup`,
-				filesDir, filesDir,
+				filesDir, filesDir, fileUid, fileGid,
 			)},
 		}).Run(t)
 	})


### PR DESCRIPTION
#116 ended up breaking [the master build](https://github.com/fornellas/resonance/actions/runs/10759341065). It looks like this branch protection rule:

![image](https://github.com/user-attachments/assets/2d8a1825-e536-4969-9cfd-4c1e254d9586)

instead of requiring "all status checks to pass", means "require NO status check to pass"... so you can actually push PRs with broken builds...

Well, I've updated the rule to this:

![image](https://github.com/user-attachments/assets/5bced5c6-166b-4ddf-b7f1-8422d4e18800)

so hopefully, we won't have a repeat of this.