### PR TITLE
Rename build.sh to make.sh

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Update Deps
         if: ${{ inputs.update-deps == true }}
         run: |
-          ./build.sh update-deps
+          ./make.sh update-deps
       # Update Deps
       - name: Diff
         if: ${{ inputs.update-deps == true }}
@@ -64,7 +64,7 @@ jobs:
       # Build
       - name: Build
         run: |
-          ./build.sh ci
+          ./make.sh ci
         shell: bash
       # Git Status
       - name: git status
@@ -108,7 +108,7 @@ jobs:
           allow-empty: true
       # Clean
       - name: Clean
-        run: ./build.sh clean
+        run: ./make.sh clean
         shell: bash
       # Git ls-files --others
       - name: git ls-files --others

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Getting started is _super easy_: just run these commands under Linux or MacOS:
 ```bash
 git clone git@github.com:fornellas/resonance.git
 cd resonance/
-./build.sh ci # runs linters, tests and build
+./make.sh ci # runs linters, tests and build
 ```
 
 That's it! The local build happens inside a [Docker](https://www.docker.com/), so it is easily reproducible on any machine.
@@ -42,7 +42,7 @@ If you're running an old Arm Mac (eg: M1), Docker is _very_ slow, you should con
 You can start a development shell, which gives you access to the whole build environemnt, including all build tools with the correct versions. Eg:
 
 ```shell
-./build.sh shell
+./make.sh shell
 make ci
 go get -u
 ```
@@ -90,7 +90,7 @@ And then start you code editor from the development shell (eg: for Sublime, do `
 The default build with `ci` reproduces the official build, but this may be too slow during development. You can use one of the `*-dev` targets to do a "dev build": bulid is a lot faster, at the expense of minimal signal loss:
 
 ```shell
-./build.sh ci-dev # or "make ci-dev"
+./make.sh ci-dev # or "make ci-dev"
 ```
 
 ### Automatic builds on Linux
@@ -100,7 +100,7 @@ The build system is integrated with [rrb](https://github.com/fornellas/rrb), whi
 First, start rrb:
 
 ```shell
-./build.sh rrb # or "make rrb"
+./make.sh rrb # or "make rrb"
 ```
 
 then just edit the files with your preferred editor. As soon as you save any file, the build will be automatically run, interrupting any ongoing build, so you always get a fresh signal.

--- a/make.sh
+++ b/make.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 function usage() {
 	echo "Usage: [DOCKER_PLATFORM=os/arch] $0 target"
-	echo "Runs the build in a predictable Docker environment."
+	echo "Runs make in a predictable Docker environment."
 	echo "'target' is a build target (try 'help')."
 	echo "DOCKER_PLATFORM can optionally be set."
 	exit 1


### PR DESCRIPTION
Long time ago this script did sttuff that calling it "build" made sense. Today, it is de facto a make wrapper, so calling for what it is, makes things easier to digest.

---

**Stack**:
- #141
- #140 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*