### PR TITLE
Add Host.ReadDir

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -33,15 +33,19 @@ type Host interface {
 	// that reads from /etc/group.
 	LookupGroup(ctx context.Context, name string) (*user.Group, error)
 
-	// Lstat works similar to os.Lstat, but returns HostFileInfo with some
-	// extra methods.
-	Lstat(ctx context.Context, name string) (HostFileInfo, error)
+	// Lstat works similar to os.Lstat, but returns a custom FileInfo struct instead of the
+	// os.FileInfo interface.
+	Lstat(ctx context.Context, name string) (FileInfo, error)
 
 	// Mkdir works similar to os.Mkdir.
 	Mkdir(ctx context.Context, name string, perm os.FileMode) error
 
 	// ReadFile works similar to os.ReadFile.
 	ReadFile(ctx context.Context, name string) ([]byte, error)
+
+	// ReadDir works similar to os.ReadDir, but returns a cumstom DirEntry struct instead of the
+	// os.DirEntry interface.
+	ReadDir(ctx context.Context, name string) ([]DirEntry, error)
 
 	// // Readlink works similar to os.Readlink.
 	// Readlink(ctx context.Context, name string) (string, error)

--- a/host/types.go
+++ b/host/types.go
@@ -3,7 +3,7 @@ package host
 import (
 	"fmt"
 	"io"
-	"io/fs"
+	"os"
 	"strings"
 	"time"
 )
@@ -84,12 +84,17 @@ func (ws *WaitStatus) String() string {
 	return str
 }
 
-type HostFileInfo struct {
-	Name    string
-	Size    int64
-	Mode    fs.FileMode
-	ModTime time.Time
-	IsDir   bool
-	Uid     uint32
-	Gid     uint32
+type FileInfo struct {
+	Name     string
+	Size     int64
+	FileMode os.FileMode
+	ModTime  time.Time
+	Uid      uint32
+	Gid      uint32
 }
+
+func (f *FileInfo) IsDir() bool {
+	return f.FileMode.IsDir()
+}
+
+type DirEntry FileInfo

--- a/internal/host/agent_http_client.go
+++ b/internal/host/agent_http_client.go
@@ -237,23 +237,23 @@ func (a AgentHttpClient) LookupGroup(ctx context.Context, name string) (*user.Gr
 	return &g, nil
 }
 
-func (a AgentHttpClient) Lstat(ctx context.Context, name string) (host.HostFileInfo, error) {
+func (a AgentHttpClient) Lstat(ctx context.Context, name string) (host.FileInfo, error) {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Lstat", "name", name)
 
 	if !filepath.IsAbs(name) {
-		return host.HostFileInfo{}, fmt.Errorf("path must be absolute: %s", name)
+		return host.FileInfo{}, fmt.Errorf("path must be absolute: %s", name)
 	}
 
 	resp, err := a.get(fmt.Sprintf("/file%s?lstat=true", name))
 	if err != nil {
-		return host.HostFileInfo{}, err
+		return host.FileInfo{}, err
 	}
 
-	var hfi host.HostFileInfo
+	var hfi host.FileInfo
 	if err := a.unmarshalResponse(resp, &hfi); err != nil {
-		return host.HostFileInfo{}, err
+		return host.FileInfo{}, err
 	}
 	hfi.ModTime = hfi.ModTime.Local()
 	return hfi, nil
@@ -296,6 +296,10 @@ func (a AgentHttpClient) ReadFile(ctx context.Context, name string) ([]byte, err
 	}
 
 	return contents, nil
+}
+
+func (a AgentHttpClient) ReadDir(ctx context.Context, name string) ([]host.DirEntry, error) {
+	panic("TODO AgentHttpClientv.ReadDir")
 }
 
 func (a AgentHttpClient) Remove(ctx context.Context, name string) error {

--- a/internal/host/agent_server_http/main.go
+++ b/internal/host/agent_server_http/main.go
@@ -116,14 +116,13 @@ func GetFileFn(ctx context.Context) func(http.ResponseWriter, *http.Request) {
 				return
 			}
 			stat_t := fileInfo.Sys().(*syscall.Stat_t)
-			hfi := host.HostFileInfo{
-				Name:    filepath.Base(name),
-				Size:    fileInfo.Size(),
-				Mode:    fileInfo.Mode(),
-				ModTime: fileInfo.ModTime(),
-				IsDir:   fileInfo.IsDir(),
-				Uid:     stat_t.Uid,
-				Gid:     stat_t.Gid,
+			hfi := host.FileInfo{
+				Name:     filepath.Base(name),
+				Size:     fileInfo.Size(),
+				FileMode: fileInfo.Mode(),
+				ModTime:  fileInfo.ModTime(),
+				Uid:      stat_t.Uid,
+				Gid:      stat_t.Gid,
 			}
 			marshalResponse(w, hfi)
 			return

--- a/internal/host/cmd_run_linux_test.go
+++ b/internal/host/cmd_run_linux_test.go
@@ -41,10 +41,10 @@ func (h cmdHostOnly) LookupGroup(ctx context.Context, name string) (*user.Group,
 	return nil, err
 }
 
-func (h cmdHostOnly) Lstat(ctx context.Context, name string) (host.HostFileInfo, error) {
+func (h cmdHostOnly) Lstat(ctx context.Context, name string) (host.FileInfo, error) {
 	err := errors.New("unexpected call received: Lstat")
 	h.T.Fatal(err)
-	return host.HostFileInfo{}, err
+	return host.FileInfo{}, err
 }
 
 func (h cmdHostOnly) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
@@ -55,6 +55,12 @@ func (h cmdHostOnly) Mkdir(ctx context.Context, name string, perm os.FileMode) e
 
 func (h cmdHostOnly) ReadFile(ctx context.Context, name string) ([]byte, error) {
 	err := errors.New("unexpected call received: ReadFile")
+	h.T.Fatal(err)
+	return nil, err
+}
+
+func (h cmdHostOnly) ReadDir(ctx context.Context, name string) ([]host.DirEntry, error) {
+	err := errors.New("unexpected call received: ReadDir")
 	h.T.Fatal(err)
 	return nil, err
 }

--- a/resources/file.go
+++ b/resources/file.go
@@ -74,7 +74,7 @@ func (f *File) Load(ctx context.Context, hst host.Host) error {
 	}
 
 	// Perm
-	f.Perm = fileInfo.Mode
+	f.Perm = fileInfo.FileMode
 
 	// Uid
 	f.Uid = fileInfo.Uid


### PR DESCRIPTION
Add `Host.ReadDir` to the interface. This should be useful generally speaking, but what triggered me to add it, was my [experimentatior with host audit](https://github.com/fornellas/resonance/blob/audit/internal/audit/files.go#L28) (TLDR, try to generate resonance automation automagically, to help onboard new hosts).

This required implementing the interface for all cases, doing some small tweaks. Of course, added tests to cover it all.