### PR TITLE
Fix Host not enforcing absolute paths

### DIFF
--- a/internal/host/cmd_run.go
+++ b/internal/host/cmd_run.go
@@ -34,6 +34,14 @@ func (br cmdHost) Chmod(ctx context.Context, name string, mode os.FileMode) erro
 
 	logger.Debug("Chmod", "name", name, "mode", mode)
 
+	if !filepath.IsAbs(name) {
+		return &fs.PathError{
+			Op:   "Chmod",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	cmd := host.Cmd{
 		Path: "chmod",
 		Args: []string{fmt.Sprintf("%o", mode), name},
@@ -64,6 +72,14 @@ func (br cmdHost) Chown(ctx context.Context, name string, uid, gid int) error {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Chown", "name", name, "uid", uid, "gid", gid)
+
+	if !filepath.IsAbs(name) {
+		return &fs.PathError{
+			Op:   "Chown",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
 
 	cmd := host.Cmd{
 		Path: "chown",
@@ -210,6 +226,14 @@ func (br cmdHost) Lstat(ctx context.Context, name string) (host.HostFileInfo, er
 
 	logger.Debug("Lstat", "name", name)
 
+	if !filepath.IsAbs(name) {
+		return host.HostFileInfo{}, &fs.PathError{
+			Op:   "Lstat",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	stdout, err := br.stat(ctx, name)
 	if err != nil {
 		return host.HostFileInfo{}, err
@@ -298,6 +322,14 @@ func (br cmdHost) Mkdir(ctx context.Context, name string, perm os.FileMode) erro
 
 	logger.Debug("Mkdir", "name", name, "perm", perm)
 
+	if !filepath.IsAbs(name) {
+		return &fs.PathError{
+			Op:   "Mkdir",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	cmd := host.Cmd{
 		Path: "mkdir",
 		Args: []string{name},
@@ -329,6 +361,14 @@ func (br cmdHost) ReadFile(ctx context.Context, name string) ([]byte, error) {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("ReadFile", "name", name)
+
+	if !filepath.IsAbs(name) {
+		return nil, &fs.PathError{
+			Op:   "ReadFile",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
 
 	cmd := host.Cmd{
 		Path: "cat",
@@ -379,6 +419,14 @@ func (br cmdHost) Remove(ctx context.Context, name string) error {
 
 	logger.Debug("Remove", "name", name)
 
+	if !filepath.IsAbs(name) {
+		return &fs.PathError{
+			Op:   "Remove",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	cmd := host.Cmd{
 		Path: "rm",
 		Args: []string{name},
@@ -409,6 +457,14 @@ func (br cmdHost) WriteFile(ctx context.Context, name string, data []byte, perm 
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("WriteFile", "name", name, "data", data, "perm", perm)
+
+	if !filepath.IsAbs(name) {
+		return &fs.PathError{
+			Op:   "WriteFile",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
 
 	var chmod bool
 	if _, err := br.Lstat(ctx, name); errors.Is(err, os.ErrNotExist) {

--- a/internal/host/local_linux.go
+++ b/internal/host/local_linux.go
@@ -2,6 +2,8 @@ package host
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -18,12 +20,30 @@ type Local struct{}
 func (l Local) Chmod(ctx context.Context, name string, mode os.FileMode) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Chmod", "name", name, "mode", mode)
+
+	if !filepath.IsAbs(name) {
+		return &fs.PathError{
+			Op:   "Chmod",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	return os.Chmod(name, mode)
 }
 
 func (l Local) Chown(ctx context.Context, name string, uid, gid int) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Chown", "name", name, "uid", uid, "gid", gid)
+
+	if !filepath.IsAbs(name) {
+		return &fs.PathError{
+			Op:   "Chown",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	return os.Chown(name, uid, gid)
 }
 
@@ -42,6 +62,15 @@ func (l Local) LookupGroup(ctx context.Context, name string) (*user.Group, error
 func (l Local) Lstat(ctx context.Context, name string) (host.HostFileInfo, error) {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Lstat", "name", name)
+
+	if !filepath.IsAbs(name) {
+		return host.HostFileInfo{}, &fs.PathError{
+			Op:   "Lstat",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	fileInfo, err := os.Lstat(name)
 	if err != nil {
 		return host.HostFileInfo{}, err
@@ -61,18 +90,45 @@ func (l Local) Lstat(ctx context.Context, name string) (host.HostFileInfo, error
 func (l Local) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Mkdir", "name", name, "perm", perm)
+
+	if !filepath.IsAbs(name) {
+		return &fs.PathError{
+			Op:   "Mkdir",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	return os.Mkdir(name, perm)
 }
 
 func (l Local) ReadFile(ctx context.Context, name string) ([]byte, error) {
 	logger := log.MustLogger(ctx)
 	logger.Debug("ReadFile", "name", name)
+
+	if !filepath.IsAbs(name) {
+		return nil, &fs.PathError{
+			Op:   "ReadFile",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	return os.ReadFile(name)
 }
 
 func (l Local) Remove(ctx context.Context, name string) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Remove", "name", name)
+
+	if !filepath.IsAbs(name) {
+		return &fs.PathError{
+			Op:   "Remove",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	return os.Remove(name)
 }
 
@@ -85,6 +141,15 @@ func (l Local) Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus, error) {
 func (l Local) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("WriteFile", "name", name, "data", data, "perm", perm)
+
+	if !filepath.IsAbs(name) {
+		return &fs.PathError{
+			Op:   "WriteFile",
+			Path: name,
+			Err:  errors.New("path must be absolute"),
+		}
+	}
+
 	return os.WriteFile(name, data, perm)
 }
 

--- a/internal/host/local_run/local_run_unix.go
+++ b/internal/host/local_run/local_run_unix.go
@@ -2,8 +2,11 @@ package local_run
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -26,6 +29,13 @@ func Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus, error) {
 
 	if cmd.Dir == "" {
 		cmd.Dir = "/tmp"
+	}
+	if !filepath.IsAbs(cmd.Dir) {
+		return host.WaitStatus{}, &fs.PathError{
+			Op:   "Run",
+			Path: cmd.Dir,
+			Err:  errors.New("path must be absolute"),
+		}
 	}
 	execCmd.Dir = cmd.Dir
 

--- a/internal/host/ssh.go
+++ b/internal/host/ssh.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"os/user"
@@ -340,6 +341,13 @@ func (s Ssh) runEnv(ctx context.Context, cmd host.Cmd, ignoreCmdEnv bool) (host.
 
 	if cmd.Dir == "" {
 		cmd.Dir = "/tmp"
+	}
+	if !filepath.IsAbs(cmd.Dir) {
+		return host.WaitStatus{}, &fs.PathError{
+			Op:   "Run",
+			Path: cmd.Dir,
+			Err:  errors.New("path must be absolute"),
+		}
 	}
 
 	var args []string


### PR DESCRIPTION
Host interface has no concept of pwd, so accepting any relative paths would be ambiguous.

This PR adds tests for all path related Host interface methods, to check whether it fails with a specific error when a relative path is passed.

commit-id:014a6a18

---

**Stack**:
- #157
- #156
- #155
- #154
- #153 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*