### PR TITLE
Host.Mkdir: change from os to syscall interface

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -36,8 +36,8 @@ type Host interface {
 	// Lstat works similar to syscal.Lstat
 	Lstat(ctx context.Context, name string) (*Stat_t, error)
 
-	// Mkdir works similar to os.Mkdir.
-	Mkdir(ctx context.Context, name string, perm os.FileMode) error
+	// Mkdir works similar to syscall.Mkdir, but no umask is applied.
+	Mkdir(ctx context.Context, name string, mode uint32) error
 
 	// ReadFile works similar to os.ReadFile.
 	ReadFile(ctx context.Context, name string) ([]byte, error)

--- a/internal/host/agent_grpc_client.go
+++ b/internal/host/agent_grpc_client.go
@@ -287,7 +287,7 @@ func (a AgentGrpcClient) Lstat(ctx context.Context, name string) (*host.Stat_t, 
 	// return hfi, nil
 }
 
-func (a AgentGrpcClient) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
+func (a AgentGrpcClient) Mkdir(ctx context.Context, name string, mode uint32) error {
 	panic("todo mkdir")
 	// 	logger := log.MustLogger(ctx)
 

--- a/internal/host/agent_http_client.go
+++ b/internal/host/agent_http_client.go
@@ -281,7 +281,7 @@ func (a AgentHttpClient) Chmod(ctx context.Context, name string, mode os.FileMod
 
 	_, err := a.post(fmt.Sprintf("/file%s", name), api.File{
 		Action: api.Chmod,
-		Mode:   mode,
+		Mode:   uint32(mode),
 	})
 
 	return err
@@ -361,7 +361,7 @@ func (a AgentHttpClient) Lstat(ctx context.Context, name string) (*host.Stat_t, 
 	return &stat_t, nil
 }
 
-func (a AgentHttpClient) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
+func (a AgentHttpClient) Mkdir(ctx context.Context, name string, mode uint32) error {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Mkdir", "name", name)
@@ -372,7 +372,7 @@ func (a AgentHttpClient) Mkdir(ctx context.Context, name string, perm os.FileMod
 
 	_, err := a.post(fmt.Sprintf("/file%s", name), api.File{
 		Action: api.Mkdir,
-		Mode:   perm,
+		Mode:   mode,
 	})
 
 	return err

--- a/internal/host/agent_server_http/api/api.go
+++ b/internal/host/agent_server_http/api/api.go
@@ -19,7 +19,7 @@ const (
 
 type File struct {
 	Action FileAction
-	Mode   os.FileMode
+	Mode   uint32
 	Uid    int
 	Gid    int
 }

--- a/internal/host/agent_server_http/main_linux.go
+++ b/internal/host/agent_server_http/main_linux.go
@@ -175,15 +175,19 @@ func PostFileFn(ctx context.Context) func(http.ResponseWriter, *http.Request) {
 
 		switch file.Action {
 		case api.Chmod:
-			if err := os.Chmod(name, file.Mode); err != nil {
+			if err := syscall.Chmod(name, file.Mode); err != nil {
 				internalServerError(w, err)
 			}
 		case api.Chown:
-			if err := os.Chown(name, file.Uid, file.Gid); err != nil {
+			if err := syscall.Chown(name, file.Uid, file.Gid); err != nil {
 				internalServerError(w, err)
 			}
 		case api.Mkdir:
-			if err := os.Mkdir(name, file.Mode); err != nil {
+			if err := syscall.Mkdir(name, file.Mode); err != nil {
+				internalServerError(w, err)
+				return
+			}
+			if err := syscall.Chmod(name, file.Mode); err != nil {
 				internalServerError(w, err)
 			}
 		default:

--- a/internal/host/cmd_run.go
+++ b/internal/host/cmd_run.go
@@ -404,10 +404,10 @@ func (br cmdHost) Lstat(ctx context.Context, name string) (*host.Stat_t, error) 
 	return &stat_t, nil
 }
 
-func (br cmdHost) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
+func (br cmdHost) Mkdir(ctx context.Context, name string, mode uint32) error {
 	logger := log.MustLogger(ctx)
 
-	logger.Debug("Mkdir", "name", name, "perm", perm)
+	logger.Debug("Mkdir", "name", name, "mode", mode)
 
 	if !filepath.IsAbs(name) {
 		return &fs.PathError{
@@ -441,7 +441,7 @@ func (br cmdHost) Mkdir(ctx context.Context, name string, perm os.FileMode) erro
 		)
 	}
 
-	return br.Chmod(ctx, name, perm)
+	return br.Chmod(ctx, name, fs.FileMode(mode))
 }
 
 func (br cmdHost) ReadFile(ctx context.Context, name string) ([]byte, error) {

--- a/internal/host/cmd_run_linux_test.go
+++ b/internal/host/cmd_run_linux_test.go
@@ -47,7 +47,7 @@ func (h cmdHostOnly) Lstat(ctx context.Context, name string) (*host.Stat_t, erro
 	return nil, err
 }
 
-func (h cmdHostOnly) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
+func (h cmdHostOnly) Mkdir(ctx context.Context, name string, mode uint32) error {
 	err := errors.New("unexpected call received: Mkdir")
 	h.T.Fatal(err)
 	return err

--- a/internal/host/local_linux.go
+++ b/internal/host/local_linux.go
@@ -103,9 +103,9 @@ func (l Local) Lstat(ctx context.Context, name string) (*host.Stat_t, error) {
 	}, nil
 }
 
-func (l Local) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
+func (l Local) Mkdir(ctx context.Context, name string, mode uint32) error {
 	logger := log.MustLogger(ctx)
-	logger.Debug("Mkdir", "name", name, "perm", perm)
+	logger.Debug("Mkdir", "name", name, "mode", mode)
 
 	if !filepath.IsAbs(name) {
 		return &fs.PathError{
@@ -115,7 +115,10 @@ func (l Local) Mkdir(ctx context.Context, name string, perm os.FileMode) error {
 		}
 	}
 
-	return os.Mkdir(name, perm)
+	if err := syscall.Mkdir(name, mode); err != nil {
+		return err
+	}
+	return syscall.Chmod(name, mode)
 }
 
 func (l Local) ReadFile(ctx context.Context, name string) ([]byte, error) {

--- a/internal/host/test_helpers_linux.go
+++ b/internal/host/test_helpers_linux.go
@@ -306,13 +306,13 @@ func testHost(t *testing.T, hst host.Host) {
 		t.Run("Success", func(t *testing.T) {
 			outputBuffer.Reset()
 			name := filepath.Join(t.TempDir(), "foo")
-			fileMode := os.FileMode(0500)
+			var fileMode uint32 = 1542
 			err := hst.Mkdir(ctx, name, fileMode)
 			require.NoError(t, err)
-			fileInfo, err := os.Lstat(name)
-			require.NoError(t, err)
-			require.True(t, fileInfo.IsDir())
-			require.Equal(t, fileMode, fileInfo.Mode()&fs.ModePerm)
+			var stat_t syscall.Stat_t
+			require.NoError(t, syscall.Lstat(name, &stat_t))
+			require.True(t, stat_t.Mode&syscall.S_IFMT == syscall.S_IFDIR)
+			require.Equal(t, fileMode, stat_t.Mode&07777)
 		})
 		t.Run("path must be absolute", func(t *testing.T) {
 			outputBuffer.Reset()


### PR DESCRIPTION
os.Mkdir does not allow setting all permission bits (eg: sticky). This PR changes the interface to be syscall.Mkdir like, but without umask, so that we can actually set all mode bits.

---

**Stack**:
- #159
- #161
- #160
- #158
- #157
- #156
- #155 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*