### PR TITLE
Host.Chmod: change from os to syscall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ RRB := $(GO) run github.com/fornellas/rrb
 RRB_DEBOUNCE ?= 500ms
 RRB_IGNORE_PATTERN ?= 'internal/host/agent_server_http_linux_*_gz.go,internal/host/agent_server_grpc_linux_*_gz.go,internal/host/agent_server_grpc/proto/*.pb.go'
 RRB_LOG_LEVEL ?= info
-RRB_PATTERN ?= '**/*.{go},Makefile'
+RRB_PATTERN ?= '**/*.go,**/*.proto,Makefile'
 RRB_MAKE_TARGET ?= ci
 RRB_EXTRA_CMD ?= true
 

--- a/host/host.go
+++ b/host/host.go
@@ -10,8 +10,8 @@ import (
 
 // Host defines an interface for interacting with a host
 type Host interface {
-	// Chmod works similar to os.Chmod.
-	Chmod(ctx context.Context, name string, mode os.FileMode) error
+	// Chmod works similar to syscall.Chmod.
+	Chmod(ctx context.Context, name string, mode uint32) error
 
 	// Chown works similar to os.Chown.
 	Chown(ctx context.Context, name string, uid, gid int) error

--- a/internal/host/agent_grpc_client.go
+++ b/internal/host/agent_grpc_client.go
@@ -69,7 +69,7 @@ func NewGrpcAgent(ctx context.Context, hst host.Host) (*AgentGrpcClient, error) 
 		return nil, err
 	}
 
-	if err := hst.Chmod(ctx, agentPath, os.FileMode(0755)); err != nil {
+	if err := hst.Chmod(ctx, agentPath, 0755); err != nil {
 		return nil, err
 	}
 
@@ -167,7 +167,7 @@ func (a *AgentGrpcClient) spawn(ctx context.Context) error {
 	return nil
 }
 
-func (a AgentGrpcClient) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+func (a AgentGrpcClient) Chmod(ctx context.Context, name string, mode uint32) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Chmod", "name", name, "mode", mode)
 
@@ -178,7 +178,7 @@ func (a AgentGrpcClient) Chmod(ctx context.Context, name string, mode os.FileMod
 	Client := proto.NewHostServiceClient(a.Client)
 	_, err := Client.Chmod(ctx, &proto.ChmodRequest{
 		Name: name,
-		Mode: int32(mode),
+		Mode: mode,
 	})
 
 	if err != nil {

--- a/internal/host/agent_http_client.go
+++ b/internal/host/agent_http_client.go
@@ -72,7 +72,7 @@ func NewHttpAgent(ctx context.Context, hst host.Host) (*AgentHttpClient, error) 
 		return nil, err
 	}
 
-	if err := hst.Chmod(ctx, agentPath, os.FileMode(0755)); err != nil {
+	if err := hst.Chmod(ctx, agentPath, 0755); err != nil {
 		return nil, err
 	}
 
@@ -270,7 +270,7 @@ func (a AgentHttpClient) put(path string, body io.Reader) (*http.Response, error
 	return resp, nil
 }
 
-func (a AgentHttpClient) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+func (a AgentHttpClient) Chmod(ctx context.Context, name string, mode uint32) error {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Chmod", "name", name, "mode", mode)
@@ -281,7 +281,7 @@ func (a AgentHttpClient) Chmod(ctx context.Context, name string, mode os.FileMod
 
 	_, err := a.post(fmt.Sprintf("/file%s", name), api.File{
 		Action: api.Chmod,
-		Mode:   uint32(mode),
+		Mode:   mode,
 	})
 
 	return err

--- a/internal/host/agent_server_grpc/proto/service.proto
+++ b/internal/host/agent_server_grpc/proto/service.proto
@@ -18,7 +18,7 @@ message PingResponse {
 
 message ChmodRequest {
   string name = 1;
-  int32  mode = 2;
+  uint32  mode = 2;
 }
 
 message ChmodResponse {

--- a/internal/host/cmd_run.go
+++ b/internal/host/cmd_run.go
@@ -29,7 +29,7 @@ type cmdHost struct {
 	Host host.Host
 }
 
-func (br cmdHost) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+func (br cmdHost) Chmod(ctx context.Context, name string, mode uint32) error {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Chmod", "name", name, "mode", mode)
@@ -441,7 +441,7 @@ func (br cmdHost) Mkdir(ctx context.Context, name string, mode uint32) error {
 		)
 	}
 
-	return br.Chmod(ctx, name, fs.FileMode(mode))
+	return br.Chmod(ctx, name, mode)
 }
 
 func (br cmdHost) ReadFile(ctx context.Context, name string) ([]byte, error) {
@@ -582,7 +582,7 @@ func (br cmdHost) WriteFile(ctx context.Context, name string, data []byte, perm 
 		)
 	}
 	if chmod {
-		return br.Chmod(ctx, name, perm)
+		return br.Chmod(ctx, name, uint32(perm))
 	}
 	return nil
 }

--- a/internal/host/cmd_run_linux_test.go
+++ b/internal/host/cmd_run_linux_test.go
@@ -17,7 +17,7 @@ type cmdHostOnly struct {
 	Host host.Host
 }
 
-func (h cmdHostOnly) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+func (h cmdHostOnly) Chmod(ctx context.Context, name string, mode uint32) error {
 	err := errors.New("unexpected call received: Chmod")
 	h.T.Fatal(err)
 	return err

--- a/internal/host/local_linux.go
+++ b/internal/host/local_linux.go
@@ -17,7 +17,7 @@ import (
 // Local interacts with the local machine running the code.
 type Local struct{}
 
-func (l Local) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+func (l Local) Chmod(ctx context.Context, name string, mode uint32) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Chmod", "name", name, "mode", mode)
 
@@ -29,7 +29,7 @@ func (l Local) Chmod(ctx context.Context, name string, mode os.FileMode) error {
 		}
 	}
 
-	return os.Chmod(name, mode)
+	return syscall.Chmod(name, mode)
 }
 
 func (l Local) Chown(ctx context.Context, name string, uid, gid int) error {

--- a/internal/host/test_helpers_linux.go
+++ b/internal/host/test_helpers_linux.go
@@ -57,16 +57,16 @@ func testHost(t *testing.T, hst host.Host) {
 		file.Close()
 		t.Run("Success", func(t *testing.T) {
 			outputBuffer.Reset()
-			fileMode := os.FileMode(0247)
+			var fileMode uint32 = 01257
 			err = hst.Chmod(ctx, name, fileMode)
 			require.NoError(t, err)
-			fileInfo, err := os.Lstat(name)
-			require.NoError(t, err)
-			require.Equal(t, fileMode, fileInfo.Mode())
+			var stat_t syscall.Stat_t
+			require.NoError(t, syscall.Lstat(name, &stat_t))
+			require.Equal(t, fileMode, stat_t.Mode&07777)
 		})
 		t.Run("path must be absolute", func(t *testing.T) {
 			outputBuffer.Reset()
-			err = hst.Chmod(ctx, "foo/bar", os.FileMode(0644))
+			err = hst.Chmod(ctx, "foo/bar", 0644)
 			require.ErrorContains(t, err, "path must be absolute")
 		})
 		t.Run("ErrPermission", func(t *testing.T) {

--- a/resources/file.go
+++ b/resources/file.go
@@ -131,7 +131,7 @@ func (f *File) Apply(ctx context.Context, hst host.Host) error {
 	}
 
 	// Perm
-	if err := hst.Chmod(ctx, string(f.Path), os.FileMode(f.Mode)); err != nil {
+	if err := hst.Chmod(ctx, string(f.Path), f.Mode); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Move Chmod away from os.FileMode to proper syscall interface, to avoid any cross-os abstraction issues with os.Chmod.

---

**Stack**:
- #159
- #161
- #160
- #158
- #157
- #156 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*