### PR TITLE
Host.WriteFile move from os to syscall style

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/user"
 )
 
@@ -54,8 +53,8 @@ type Host interface {
 	// // Symlink works similar to os.Symlink.
 	// Symlink(ctx context.Context, oldname, newname string) error
 
-	// WriteFile works similar to os.WriteFile.
-	WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error
+	// WriteFile works similar to os.WriteFile, but receives mode as is syscall.Chmod argument.
+	WriteFile(ctx context.Context, name string, data []byte, mode uint32) error
 
 	// A string representation of the host which uniquely identifies it, eg, its FQDN.
 	String() string

--- a/internal/host/agent_grpc_client.go
+++ b/internal/host/agent_grpc_client.go
@@ -406,7 +406,7 @@ func (a AgentGrpcClient) Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus
 	// return cs.WaitStatus, nil
 }
 
-func (a AgentGrpcClient) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+func (a AgentGrpcClient) WriteFile(ctx context.Context, name string, data []byte, mode uint32) error {
 	panic("todo write file")
 	// 	logger := log.MustLogger(ctx)
 

--- a/internal/host/agent_http_client.go
+++ b/internal/host/agent_http_client.go
@@ -476,16 +476,16 @@ func (a AgentHttpClient) Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus
 	return cs.WaitStatus, nil
 }
 
-func (a AgentHttpClient) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+func (a AgentHttpClient) WriteFile(ctx context.Context, name string, data []byte, mode uint32) error {
 	logger := log.MustLogger(ctx)
 
-	logger.Debug("WriteFile", "name", name, "data", data, "perm", perm)
+	logger.Debug("WriteFile", "name", name, "data", data, "mode", mode)
 
 	if !filepath.IsAbs(name) {
 		return fmt.Errorf("path must be absolute: %s", name)
 	}
 
-	_, err := a.put(fmt.Sprintf("/file%s?perm=%d", name, perm), bytes.NewReader(data))
+	_, err := a.put(fmt.Sprintf("/file%s?mode=%d", name, mode), bytes.NewReader(data))
 	if err != nil {
 		return err
 	}

--- a/internal/host/cmd_run.go
+++ b/internal/host/cmd_run.go
@@ -540,10 +540,10 @@ func (br cmdHost) Remove(ctx context.Context, name string) error {
 	return nil
 }
 
-func (br cmdHost) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+func (br cmdHost) WriteFile(ctx context.Context, name string, data []byte, mode uint32) error {
 	logger := log.MustLogger(ctx)
 
-	logger.Debug("WriteFile", "name", name, "data", data, "perm", perm)
+	logger.Debug("WriteFile", "name", name, "data", data, "mode", mode)
 
 	if !filepath.IsAbs(name) {
 		return &fs.PathError{
@@ -553,10 +553,6 @@ func (br cmdHost) WriteFile(ctx context.Context, name string, data []byte, perm 
 		}
 	}
 
-	var chmod bool
-	if _, err := br.Lstat(ctx, name); errors.Is(err, os.ErrNotExist) {
-		chmod = true
-	}
 	cmd := host.Cmd{
 		Path:  "sh",
 		Args:  []string{"-c", fmt.Sprintf("cat > %s", shellescape.Quote(name))},
@@ -581,8 +577,6 @@ func (br cmdHost) WriteFile(ctx context.Context, name string, data []byte, perm 
 			cmd, waitStatus.String(), stdout, stderr,
 		)
 	}
-	if chmod {
-		return br.Chmod(ctx, name, uint32(perm))
-	}
-	return nil
+
+	return br.Chmod(ctx, name, mode)
 }

--- a/internal/host/cmd_run_linux_test.go
+++ b/internal/host/cmd_run_linux_test.go
@@ -3,7 +3,6 @@ package host
 import (
 	"context"
 	"errors"
-	"os"
 	"os/user"
 	"testing"
 
@@ -65,7 +64,7 @@ func (h cmdHostOnly) Remove(ctx context.Context, name string) error {
 	return err
 }
 
-func (h cmdHostOnly) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+func (h cmdHostOnly) WriteFile(ctx context.Context, name string, data []byte, mode uint32) error {
 	err := errors.New("unexpected call received: WriteFile")
 	h.T.Fatal(err)
 	return err

--- a/internal/host/local_linux.go
+++ b/internal/host/local_linux.go
@@ -157,9 +157,9 @@ func (l Local) Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus, error) {
 	return local_run.Run(ctx, cmd)
 }
 
-func (l Local) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+func (l Local) WriteFile(ctx context.Context, name string, data []byte, mode uint32) error {
 	logger := log.MustLogger(ctx)
-	logger.Debug("WriteFile", "name", name, "data", data, "perm", perm)
+	logger.Debug("WriteFile", "name", name, "data", data, "mode", mode)
 
 	if !filepath.IsAbs(name) {
 		return &fs.PathError{
@@ -169,7 +169,10 @@ func (l Local) WriteFile(ctx context.Context, name string, data []byte, perm os.
 		}
 	}
 
-	return os.WriteFile(name, data, perm)
+	if err := os.WriteFile(name, data, fs.FileMode(mode)); err != nil {
+		return err
+	}
+	return syscall.Chmod(name, mode)
 }
 
 func (l Local) String() string {

--- a/internal/plan/prep_linux_test.go
+++ b/internal/plan/prep_linux_test.go
@@ -65,7 +65,7 @@ func TestSaveOriginalResourcesState(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "foo")
 	fileContent := "foo"
 	var fileMode uint32 = 0644
-	err := host.WriteFile(ctx, filePath, []byte("foo"), os.FileMode(fileMode))
+	err := host.WriteFile(ctx, filePath, []byte("foo"), fileMode)
 	require.NoError(t, err)
 	fileResource := &resouresPkg.File{
 		Path:    filePath,
@@ -107,8 +107,8 @@ func TestLoadOrCreateAndSaveLastBlueprintWithValidation(t *testing.T) {
 
 	filePath := filepath.Join(t.TempDir(), "foo")
 	fileContent := "foo"
-	filePerm := os.FileMode(0644)
-	err := host.WriteFile(ctx, filePath, []byte("foo"), filePerm)
+	var fileMode uint32 = 0644
+	err := host.WriteFile(ctx, filePath, []byte("foo"), fileMode)
 	require.NoError(t, err)
 	fileResource := &resouresPkg.File{
 		Path:    filePath,

--- a/internal/store/host.go
+++ b/internal/store/host.go
@@ -222,7 +222,7 @@ func (s *HostStore) saveYaml(ctx context.Context, obj any, path string) error {
 		return err
 	}
 
-	return s.Host.WriteFile(ctx, path, blueprintBytes, os.FileMode(0600))
+	return s.Host.WriteFile(ctx, path, blueprintBytes, 0600)
 }
 
 func (s *HostStore) SaveLastBlueprint(ctx context.Context, blueprint *blueprintPkg.Blueprint) error {

--- a/resources/file.go
+++ b/resources/file.go
@@ -126,7 +126,7 @@ func (f *File) Apply(ctx context.Context, hst host.Host) error {
 	}
 
 	// Content
-	if err := hst.WriteFile(ctx, string(f.Path), []byte(f.Content), os.FileMode(f.Mode)); err != nil {
+	if err := hst.WriteFile(ctx, string(f.Path), []byte(f.Content), f.Mode); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Change Host.WriteFile to receive mode bits like os.Chmod, to fix issues with os abstraction preventing some bits from being set (eg: SUID).

---

**Stack**:
- #159
- #161
- #160
- #158
- #157 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*