### PR TITLE
Fix HTTP agent with "/" as path argument

### DIFF
--- a/internal/host/agent_server_http/main_linux.go
+++ b/internal/host/agent_server_http/main_linux.go
@@ -337,20 +337,20 @@ func main() {
 
 	router.
 		Methods("PUT").
-		Path("/file/{name:.+}").
+		Path("/file/{name:.*}").
 		HandlerFunc(PutFileFn(ctx))
 	router.
 		Methods("GET").
-		Path("/file/{name:.+}").
+		Path("/file/{name:.*}").
 		HandlerFunc(GetFileFn(ctx))
 	router.
 		Methods("POST").
-		Path("/file/{name:.+}").
+		Path("/file/{name:.*}").
 		Headers("Content-Type", "application/yaml").
 		HandlerFunc(PostFileFn(ctx))
 	router.
 		Methods("DELETE").
-		Path("/file/{name:.+}").
+		Path("/file/{name:.*}").
 		HandlerFunc(DeleteFileFn(ctx))
 
 	router.


### PR DESCRIPTION
Things like `Host.Lstat(ctx, "/")` result in 404, unless we change the regexp from `.+` to `.*`.

---

**Stack**:
- #159
- #161
- #160 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*