### PR TITLE
Change chown arg to uint32

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -12,8 +12,8 @@ type Host interface {
 	// Chmod works similar to syscall.Chmod.
 	Chmod(ctx context.Context, name string, mode uint32) error
 
-	// Chown works similar to os.Chown.
-	Chown(ctx context.Context, name string, uid, gid int) error
+	// Chown works similar to syscall.Chown.
+	Chown(ctx context.Context, name string, uid, gid uint32) error
 
 	// // Hostname works similar to os.Hostname.
 	// Hostname() (ctx context.Context, name string, err error)

--- a/internal/host/agent_grpc_client.go
+++ b/internal/host/agent_grpc_client.go
@@ -192,7 +192,7 @@ func (a AgentGrpcClient) Chmod(ctx context.Context, name string, mode uint32) er
 	return nil
 }
 
-func (a AgentGrpcClient) Chown(ctx context.Context, name string, uid, gid int) error {
+func (a AgentGrpcClient) Chown(ctx context.Context, name string, uid, gid uint32) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Chown", "name", name, "uid", uid, "gid", gid)
 
@@ -422,7 +422,6 @@ func (a AgentGrpcClient) ReadFile(ctx context.Context, name string) ([]byte, err
 	}
 
 	return fileData, nil
-
 }
 
 func (a AgentGrpcClient) Readlink(ctx context.Context, name string) (string, error) {

--- a/internal/host/agent_http_client.go
+++ b/internal/host/agent_http_client.go
@@ -285,7 +285,7 @@ func (a AgentHttpClient) Chmod(ctx context.Context, name string, mode uint32) er
 	return err
 }
 
-func (a AgentHttpClient) Chown(ctx context.Context, name string, uid, gid int) error {
+func (a AgentHttpClient) Chown(ctx context.Context, name string, uid, gid uint32) error {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Chown", "name", name, "uid", uid, "gid", gid)

--- a/internal/host/agent_server_http/api/api.go
+++ b/internal/host/agent_server_http/api/api.go
@@ -20,8 +20,8 @@ const (
 type File struct {
 	Action FileAction
 	Mode   uint32
-	Uid    int
-	Gid    int
+	Uid    uint32
+	Gid    uint32
 }
 
 type Error struct {

--- a/internal/host/agent_server_http/main_linux.go
+++ b/internal/host/agent_server_http/main_linux.go
@@ -195,7 +195,7 @@ func PostFileFn(ctx context.Context) func(http.ResponseWriter, *http.Request) {
 				internalServerError(w, err)
 			}
 		case api.Chown:
-			if err := syscall.Chown(name, file.Uid, file.Gid); err != nil {
+			if err := syscall.Chown(name, int(file.Uid), int(file.Gid)); err != nil {
 				internalServerError(w, err)
 			}
 		case api.Mkdir:

--- a/internal/host/cmd_run.go
+++ b/internal/host/cmd_run.go
@@ -69,7 +69,7 @@ func (br cmdHost) Chmod(ctx context.Context, name string, mode uint32) error {
 	)
 }
 
-func (br cmdHost) Chown(ctx context.Context, name string, uid, gid int) error {
+func (br cmdHost) Chown(ctx context.Context, name string, uid, gid uint32) error {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Chown", "name", name, "uid", uid, "gid", gid)

--- a/internal/host/cmd_run_linux_test.go
+++ b/internal/host/cmd_run_linux_test.go
@@ -22,7 +22,7 @@ func (h cmdHostOnly) Chmod(ctx context.Context, name string, mode uint32) error 
 	return err
 }
 
-func (h cmdHostOnly) Chown(ctx context.Context, name string, uid, gid int) error {
+func (h cmdHostOnly) Chown(ctx context.Context, name string, uid, gid uint32) error {
 	err := errors.New("unexpected call received: Chown")
 	h.T.Fatal(err)
 	return err

--- a/internal/host/local_linux.go
+++ b/internal/host/local_linux.go
@@ -32,7 +32,7 @@ func (l Local) Chmod(ctx context.Context, name string, mode uint32) error {
 	return syscall.Chmod(name, mode)
 }
 
-func (l Local) Chown(ctx context.Context, name string, uid, gid int) error {
+func (l Local) Chown(ctx context.Context, name string, uid, gid uint32) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Chown", "name", name, "uid", uid, "gid", gid)
 
@@ -44,7 +44,7 @@ func (l Local) Chown(ctx context.Context, name string, uid, gid int) error {
 		}
 	}
 
-	return os.Chown(name, uid, gid)
+	return syscall.Chown(name, int(uid), int(gid))
 }
 
 func (l Local) Lookup(ctx context.Context, username string) (*user.User, error) {

--- a/internal/host/test_helpers_linux.go
+++ b/internal/host/test_helpers_linux.go
@@ -91,7 +91,7 @@ func testHost(t *testing.T, hst host.Host) {
 			fileInfo, err := os.Lstat(name)
 			require.NoError(t, err)
 			stat_t := fileInfo.Sys().(*syscall.Stat_t)
-			err = hst.Chown(ctx, name, int(stat_t.Uid), int(stat_t.Gid))
+			err = hst.Chown(ctx, name, stat_t.Uid, stat_t.Gid)
 			require.NoError(t, err)
 		})
 		t.Run("path must be absolute", func(t *testing.T) {

--- a/resources/file.go
+++ b/resources/file.go
@@ -143,7 +143,7 @@ func (f *File) Apply(ctx context.Context, hst host.Host) error {
 
 	// Uid / Gid
 	if fileInfo.Uid != f.Uid || fileInfo.Gid != f.Gid {
-		if err := hst.Chown(ctx, string(f.Path), int(f.Uid), int(f.Gid)); err != nil {
+		if err := hst.Chown(ctx, string(f.Path), f.Uid, f.Gid); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This type should be uint32 (see [here](https://pkg.go.dev/syscall#Stat_t)), even on 64 bit archs.

commit-id:336fd6ff

---

**Stack**:
- #159
- #165
- #179
- #178
- #176 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*