### PR TITLE
Misc fixes & improvements

### DIFF
--- a/internal/host/agent_server_grpc/main_linux.go
+++ b/internal/host/agent_server_grpc/main_linux.go
@@ -321,12 +321,12 @@ func (s *HostService) Shutdown(ctx context.Context, _ *proto.Empty) (*proto.Empt
 }
 
 func main() {
-	conn := aNet.Conn{
+	ioConn := aNet.IOConn{
 		Reader: os.Stdin,
 		Writer: os.Stdout,
 	}
 
-	pipeListener := aNet.NewListener(conn)
+	pipeListener := aNet.NewListener(ioConn)
 
 	grpcServer := grpc.NewServer()
 

--- a/internal/host/agent_server_http/main_linux.go
+++ b/internal/host/agent_server_http/main_linux.go
@@ -389,10 +389,10 @@ func main() {
 		Handler: h2c.NewHandler(router, server),
 	}
 
-	conn := aNet.Conn{
+	ioConn := aNet.IOConn{
 		Reader: os.Stdin,
 		Writer: os.Stdout,
 	}
 
-	server.ServeConn(conn, serveConnOpts)
+	server.ServeConn(ioConn, serveConnOpts)
 }

--- a/internal/host/agent_server_http/net/net.go
+++ b/internal/host/agent_server_http/net/net.go
@@ -24,50 +24,50 @@ func (a Addr) String() string {
 	return fmt.Sprintf("%v<>%v", a.Reader, a.Writer)
 }
 
-// Conn implements net.Conn for io.ReadCloser / io.WriteCloser.
-type Conn struct {
+// IOConn implements net.IOConn for io.ReadCloser / io.WriteCloser.
+type IOConn struct {
 	Reader io.ReadCloser
 	Writer io.WriteCloser
 }
 
-func (c Conn) Read(b []byte) (int, error) {
+func (c IOConn) Read(b []byte) (int, error) {
 	n, err := c.Reader.Read(b)
 	return n, err
 }
 
-func (c Conn) Write(b []byte) (int, error) {
+func (c IOConn) Write(b []byte) (int, error) {
 	n, err := c.Writer.Write(b)
 	return n, err
 }
 
-func (c Conn) Close() error {
+func (c IOConn) Close() error {
 	return multierr.Combine(
 		c.Reader.Close(),
 		c.Writer.Close(),
 	)
 }
 
-func (c Conn) LocalAddr() net.Addr {
+func (c IOConn) LocalAddr() net.Addr {
 	return Addr{
 		Reader: c.Reader,
 	}
 }
 
-func (c Conn) RemoteAddr() net.Addr {
+func (c IOConn) RemoteAddr() net.Addr {
 	return Addr{
 		Writer: c.Writer,
 	}
 }
 
-func (c Conn) SetDeadline(t time.Time) error {
+func (c IOConn) SetDeadline(t time.Time) error {
 	return os.ErrNoDeadline
 }
 
-func (c Conn) SetReadDeadline(t time.Time) error {
+func (c IOConn) SetReadDeadline(t time.Time) error {
 	return os.ErrNoDeadline
 }
 
-func (c Conn) SetWriteDeadline(t time.Time) error {
+func (c IOConn) SetWriteDeadline(t time.Time) error {
 	return os.ErrNoDeadline
 }
 

--- a/internal/host/docker_unix.go
+++ b/internal/host/docker_unix.go
@@ -96,7 +96,7 @@ func (d Docker) Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus, error) 
 }
 
 func (d Docker) String() string {
-	return fmt.Sprintf(d.ConnectionString)
+	return d.ConnectionString
 }
 
 func (d Docker) Type() string {

--- a/internal/host/ssh.go
+++ b/internal/host/ssh.go
@@ -148,9 +148,7 @@ func sshGetSigners(ctx context.Context) ([]ssh.Signer, error) {
 	return signers, nil
 }
 
-func sshGetHostKeyCallback(
-	ctx context.Context, host string, port int, fingerprint string,
-) (ssh.HostKeyCallback, error) {
+func sshGetHostKeyCallback(ctx context.Context, fingerprint string) (ssh.HostKeyCallback, error) {
 	logger := log.MustLogger(ctx)
 
 	var fingerprintHostKeyCallback ssh.HostKeyCallback
@@ -241,7 +239,7 @@ func NewSsh(
 	if err != nil {
 		return Ssh{}, err
 	}
-	hostKeyCallback, err := sshGetHostKeyCallback(ctx, host, port, fingerprint)
+	hostKeyCallback, err := sshGetHostKeyCallback(ctx, fingerprint)
 	if err != nil {
 		return Ssh{}, err
 	}


### PR DESCRIPTION
- `internal/host/docker_unix.go` fix bad sprintf usage.
- `internal/host/ssh.go` drop unused arguments.
- `internal/host/agent_server_http/net/net.go` rename `Conn` to `IOConn`, as... it is a connection for any I/O object (eg: a pipe).
- `internal/host/agent_http_client.go` improve error catching and reporting for the agent server shutdown.
- `internal/host/agent_grpc_client.go` simplify code a bit, moving client to contructor, fix a potential bug on Close (we shouldn't wait on spawn channel when we fail to ask for shutdown) & misc bits.

---

**Stack**:
- #159
- #165
- #188 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*