### PR TITLE
Use GH arm runner

### DIFF
--- a/.github/workflows/build-darwin.yaml
+++ b/.github/workflows/build-darwin.yaml
@@ -19,10 +19,10 @@ jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
     env:
-        GOOS: darwin
-        GOARCH: ${{ inputs.GOARCH }}
-        XDG_CACHE_HOME: /tmp/XDG_CACHE_HOME
-        GO_TEST_BINARY_FLAGS_EXTRA: -v
+      GOOS: darwin
+      GOARCH: ${{ inputs.GOARCH }}
+      XDG_CACHE_HOME: /tmp/XDG_CACHE_HOME
+      GO_TEST_BINARY_FLAGS_EXTRA: -v
     steps:
       # Checkout
       - name: Checkout
@@ -80,7 +80,7 @@ jobs:
           if-no-files-found: error
       # Coveralls
       - name: Coveralls
-        uses: coverallsapp/github-action@v2.3.0
+        uses: coverallsapp/github-action@v2.3.4
         with:
           file: cover.lcov
           flag-name: darwin.${{ inputs.GOARCH }}

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -9,6 +9,9 @@ on:
       GOARCH:
         required: true
         type: string
+      runs-on:
+        required: true
+        type: string
       update-deps:
         required: false
         type: boolean
@@ -22,24 +25,17 @@ on:
         value: resonance.linux.${{ inputs.GOARCH }}.gz
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     env:
-        GOOS: linux
-        GOARCH: ${{ inputs.GOARCH }}
-        XDG_CACHE_HOME: /tmp/XDG_CACHE_HOME
-        DOCKER_PLATFORM: linux/${{ inputs.GOARCH }}
-        GO_TEST_BINARY_FLAGS_EXTRA: -v
+      GOOS: linux
+      GOARCH: ${{ inputs.GOARCH }}
+      XDG_CACHE_HOME: /tmp/XDG_CACHE_HOME
+      DOCKER_PLATFORM: linux/${{ inputs.GOARCH }}
+      GO_TEST_BINARY_FLAGS_EXTRA: -v
     steps:
       # Checkout
       - name: Checkout
         uses: actions/checkout@v4
-      # Architecture support
-      - name: Architecture support
-        if: ${{ inputs.GOARCH != '386' && inputs.GOARCH != 'amd64' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install binfmt-support qemu-user-static
-        shell: bash
       # Cache restore
       - name: Cache restore
         uses: actions/cache/restore@v4
@@ -100,12 +96,13 @@ jobs:
       # Coveralls
       - name: Coveralls
         if: ${{ inputs.coveralls == true }}
-        uses: coverallsapp/github-action@v2.3.0
+        uses: coverallsapp/github-action@v2.3.4
         with:
           file: cover.lcov
           flag-name: linux.${{ inputs.GOARCH }}
           parallel: true
           allow-empty: true
+          coverage-reporter-platform: ${{ inputs.GOARCH == '386' || inputs.GOARCH == 'amd64' && 'x86_64' || inputs.GOARCH == 'arm64' && 'arm64' }}
       # Clean
       - name: Clean
         run: ./build.sh clean

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -2,23 +2,26 @@ name: pull_request
 on:
   pull_request:
     branches:
-      - 'master'
-      - 'spr/master/*'
+      - "master"
+      - "spr/master/*"
 jobs:
   linux_386:
     uses: ./.github/workflows/build-linux.yaml
     with:
       GOARCH: 386
+      runs-on: ubuntu-24.04
     secrets: inherit
   linux_amd64:
     uses: ./.github/workflows/build-linux.yaml
     with:
       GOARCH: amd64
+      runs-on: ubuntu-24.04
     secrets: inherit
   linux_arm64:
     uses: ./.github/workflows/build-linux.yaml
     with:
       GOARCH: arm64
+      runs-on: ubuntu-24.04-arm
     secrets: inherit
   darwin_amd64:
     uses: ./.github/workflows/build-darwin.yaml
@@ -42,10 +45,10 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2.3.0
-      with:
-        parallel-finished: true
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2.3.4
+        with:
+          parallel-finished: true
   spr:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -2,7 +2,7 @@ name: push
 on:
   push:
     branches:
-      - 'master'
+      - "master"
     tags:
       - "v*"
 jobs:
@@ -11,18 +11,21 @@ jobs:
     with:
       upload-artifact: ${{ startsWith(github.ref, 'refs/tags/') }}
       GOARCH: 386
+      runs-on: ubuntu-24.04
     secrets: inherit
   linux_amd64:
     uses: ./.github/workflows/build-linux.yaml
     with:
       upload-artifact: ${{ startsWith(github.ref, 'refs/tags/') }}
       GOARCH: amd64
+      runs-on: ubuntu-24.04
     secrets: inherit
   linux_arm64:
     uses: ./.github/workflows/build-linux.yaml
     with:
       upload-artifact: ${{ startsWith(github.ref, 'refs/tags/') }}
       GOARCH: arm64
+      runs-on: ubuntu-24.04-arm
     secrets: inherit
   darwin_amd64:
     uses: ./.github/workflows/build-darwin.yaml
@@ -91,7 +94,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2.3.0
-      with:
-        parallel-finished: true
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2.3.4
+        with:
+          parallel-finished: true


### PR DESCRIPTION
[GitHub now has arm64 runners ](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/), which can run the arm64 build in [~54s](https://github.com/fornellas/resonance/actions/runs/12817609288/job/35741226828?pr=191#step:7:1) vs in [~22min](https://github.com/fornellas/resonance/actions/runs/12753584021/job/35545562325#step:8:1) when under qemu emulating arm64 under amd64. Let's make use of it.