### PR TITLE
Fix store wrongly using os.Mkdirall

### DIFF
--- a/internal/store/host.go
+++ b/internal/store/host.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -220,7 +219,7 @@ func (s *HostStore) saveYaml(ctx context.Context, obj any, path string) error {
 
 	dir := filepath.Dir(path)
 
-	if err := os.MkdirAll(dir, fs.FileMode(0700)); err != nil {
+	if err := host.MkdirAll(ctx, s.Host, dir, 0700); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We should have been using the Host interface, this PR fixes that.

---

**Stack**:
- #159
- #209
- #208
- #215
- #216
- #202
- #211
- #214
- #212
- #204
- #213
- #210
- #207
- #206 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*