### PR TITLE
File: support all file types

### DIFF
--- a/blueprint/step_linux_test.go
+++ b/blueprint/step_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	hostPkg "github.com/fornellas/resonance/host"
+	"github.com/fornellas/resonance/host/types"
 	"github.com/fornellas/resonance/log"
 	resourcesPkg "github.com/fornellas/resonance/resources"
 )
@@ -24,22 +25,23 @@ func TestStepMisc(t *testing.T) {
 		yaml           string
 	}
 
+	var mode types.FileMode = 0644
 	testCases := []testCase{
 		{
 			name:         "SingleResource",
 			resourceType: "File",
 			singleResource: &resourcesPkg.File{
 				Path: "/tmp/foo",
-				Mode: 0644,
+				Mode: &mode,
 			},
 			string: "File:/tmp/foo",
 			detailedString: `File:
   path: /tmp/foo
-  mode: 420`,
+  mode: "0644"`,
 			yaml: `single_resource_type: File
 single_resource:
     path: /tmp/foo
-    mode: 420
+    mode: "0644"
 `,
 		},
 		{
@@ -117,14 +119,20 @@ func TestStepResolve(t *testing.T) {
 	ctx = log.WithTestLogger(ctx)
 	localhost := hostPkg.Local{}
 
+	fileContent := "foo"
+	user := "root"
 	step := NewSingleResourceStep(&resourcesPkg.File{
-		Path: "/bin",
-		User: "root",
+		Path:        "/bin",
+		RegularFile: &fileContent,
+		User:        &user,
 	})
 	step.Resolve(ctx, localhost)
 	require.Equal(t,
 		&resourcesPkg.File{
-			Path: "/bin",
+			Path:        "/bin",
+			RegularFile: &fileContent,
+			Uid:         new(uint32),
+			Gid:         new(uint32),
 		},
 		step.Resources()[0],
 	)

--- a/cmd/apply_linux_test.go
+++ b/cmd/apply_linux_test.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	resouresPkg "github.com/fornellas/resonance/resources"
+	"github.com/fornellas/resonance/host/types"
+	resourcesPkg "github.com/fornellas/resonance/resources"
 )
 
 func TestApply(t *testing.T) {
@@ -23,14 +24,14 @@ func TestApply(t *testing.T) {
 	fileContent := "bar"
 	fileUid := uint32(os.Geteuid())
 	fileGid := uint32(os.Getgid())
-
-	resources := resouresPkg.Resources{
-		&resouresPkg.File{
-			Path:    filepath.Join(filesDir, "bar"),
-			Mode:    0644,
-			Content: fileContent,
-			Uid:     fileUid,
-			Gid:     fileGid,
+	var mode types.FileMode = 0644
+	resources := resourcesPkg.Resources{
+		&resourcesPkg.File{
+			Path:        filepath.Join(filesDir, "bar"),
+			Mode:        &mode,
+			RegularFile: &fileContent,
+			Uid:         &fileUid,
+			Gid:         &fileGid,
 		},
 	}
 
@@ -50,8 +51,8 @@ func TestApply(t *testing.T) {
     diff:
       path: %s/bar
       -absent: true
-      +content: bar
-      +mode: 420
+      +regular_file: bar
+      +mode: "0644"
       +uid: %d
       +gid: %d
 🧹 State cleanup`,

--- a/cmd/plan_linux_test.go
+++ b/cmd/plan_linux_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/fornellas/resonance/host/types"
 	resouresPkg "github.com/fornellas/resonance/resources"
 )
 
@@ -19,14 +20,17 @@ func TestPlan(t *testing.T) {
 		resourcesDir := filepath.Join(tempDir, "resources")
 		resourcesFile := filepath.Join(resourcesDir, "resources.yaml")
 		filesDir := filepath.Join(tempDir, "files")
-
+		fileContent := "bar"
+		user := "root"
+		group := "root"
+		var mode types.FileMode = 0644
 		resources := resouresPkg.Resources{
 			&resouresPkg.File{
-				Path:    filepath.Join(filesDir, "bar"),
-				Mode:    0644,
-				Content: "bar",
-				User:    "root",
-				Group:   "root",
+				Path:        filepath.Join(filesDir, "bar"),
+				Mode:        &mode,
+				RegularFile: &fileContent,
+				User:        &user,
+				Group:       &group,
 			},
 		}
 
@@ -46,8 +50,10 @@ func TestPlan(t *testing.T) {
     diff:
       path: %s/bar
       -absent: true
-      +content: bar
-      +mode: 420
+      +regular_file: bar
+      +mode: "0644"
+      +uid: 0
+      +gid: 0
 🎆 Planning successful`,
 				filesDir, filesDir,
 			)},
@@ -64,18 +70,20 @@ func TestPlan(t *testing.T) {
 		err := os.MkdirAll(filesDir, fs.FileMode(0755))
 		require.NoError(t, err)
 		filePath := filepath.Join(filesDir, "bar")
-		var fileMode uint32 = 0644
+		var fileMode types.FileMode = 0644
 		fileContent := "bar"
 		err = os.WriteFile(filePath, []byte(fileContent), os.FileMode(fileMode))
 		require.NoError(t, err)
+		uid := uint32(os.Geteuid())
+		gid := uint32(os.Getegid())
 
 		resources := resouresPkg.Resources{
 			&resouresPkg.File{
-				Path:    filePath,
-				Mode:    fileMode,
-				Content: fileContent,
-				Uid:     uint32(os.Geteuid()),
-				Gid:     uint32(os.Getegid()),
+				Path:        filePath,
+				Mode:        &fileMode,
+				RegularFile: &fileContent,
+				Uid:         &uid,
+				Gid:         &gid,
 			},
 		}
 

--- a/cmd/validate_linux_test.go
+++ b/cmd/validate_linux_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/fornellas/resonance/host/types"
 	resouresPkg "github.com/fornellas/resonance/resources"
 )
 
@@ -12,10 +13,14 @@ func TestValidate(t *testing.T) {
 	resourcesDir := tempDir
 	resourcesFile := filepath.Join(tempDir, "resources.yaml")
 
+	var mode types.FileMode = 0644
+
+	regularFile := "foo"
 	successResources := resouresPkg.Resources{
 		&resouresPkg.File{
-			Path: filepath.Join(tempDir, "foo"),
-			Mode: 0644,
+			Path:        filepath.Join(tempDir, "foo"),
+			RegularFile: &regularFile,
+			Mode:        &mode,
 		},
 	}
 
@@ -42,6 +47,7 @@ func TestValidate(t *testing.T) {
 		ExpectStderrContains []string
 	}
 
+	badUser := "bad-user-name"
 	for _, tc := range []testCase{
 		{
 			Name:                 "success",
@@ -53,8 +59,8 @@ func TestValidate(t *testing.T) {
 			Resources: resouresPkg.Resources{
 				&resouresPkg.File{
 					Path: filepath.Join(tempDir, "foo"),
-					Mode: 0644,
-					User: "bad-user-name",
+					Mode: &mode,
+					User: &badUser,
 				},
 			},
 			ExpectedCode:         1,

--- a/host/agent_client_wrapper.go
+++ b/host/agent_client_wrapper.go
@@ -128,7 +128,7 @@ func getTmpFile(ctx context.Context, hst types.BaseHost, template string) (strin
 	return strings.TrimRight(stdout, "\n"), nil
 }
 
-func chmod(ctx context.Context, baseHost types.BaseHost, name string, mode uint32) error {
+func chmod(ctx context.Context, baseHost types.BaseHost, name string, mode types.FileMode) error {
 	cmd := types.Cmd{
 		Path: "chmod",
 		Args: []string{fmt.Sprintf("%o", mode), name},
@@ -359,13 +359,13 @@ func (h *AgentClientWrapper) Getegid(ctx context.Context) (uint64, error) {
 	return getgidResponse.Gid, nil
 }
 
-func (h *AgentClientWrapper) Chmod(ctx context.Context, name string, mode uint32) error {
+func (h *AgentClientWrapper) Chmod(ctx context.Context, name string, mode types.FileMode) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Chmod", "name", name, "mode", mode)
 
 	_, err := h.hostServiceClient.Chmod(ctx, &proto.ChmodRequest{
 		Name: name,
-		Mode: mode,
+		Mode: uint32(mode),
 	})
 
 	if err != nil {
@@ -529,14 +529,14 @@ func (h *AgentClientWrapper) ReadDir(ctx context.Context, name string) (<-chan t
 	return dirEntResultCh, cancel
 }
 
-func (h *AgentClientWrapper) Mkdir(ctx context.Context, name string, mode uint32) error {
+func (h *AgentClientWrapper) Mkdir(ctx context.Context, name string, mode types.FileMode) error {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("Mkdir", "name", name)
 
 	_, err := h.hostServiceClient.Mkdir(ctx, &proto.MkdirRequest{
 		Name: name,
-		Mode: mode,
+		Mode: uint32(mode),
 	})
 	if err != nil {
 		return unwrapGrpcStatusErrno(err)
@@ -626,14 +626,14 @@ func (h *AgentClientWrapper) Remove(ctx context.Context, name string) error {
 	return nil
 }
 
-func (h *AgentClientWrapper) Mknod(ctx context.Context, pathName string, mode uint32, dev uint64) error {
+func (h *AgentClientWrapper) Mknod(ctx context.Context, pathName string, mode types.FileMode, dev types.FileDevice) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Mknod", "pathName", pathName, "mode", mode, "dev", dev)
 
 	_, err := h.hostServiceClient.Mknod(ctx, &proto.MknodRequest{
 		Path: pathName,
-		Mode: mode,
-		Dev:  dev,
+		Mode: uint32(mode),
+		Dev:  uint64(dev),
 	})
 	if err != nil {
 		return unwrapGrpcStatusErrno(err)
@@ -765,7 +765,7 @@ func (h *AgentClientWrapper) Run(ctx context.Context, cmd types.Cmd) (types.Wait
 	return waitStatus, nil
 }
 
-func (h *AgentClientWrapper) WriteFile(ctx context.Context, name string, data io.Reader, perm uint32) error {
+func (h *AgentClientWrapper) WriteFile(ctx context.Context, name string, data io.Reader, perm types.FileMode) error {
 	logger := log.MustLogger(ctx)
 
 	logger.Debug("WriteFile", "name", name, "data", data, "perm", perm)
@@ -780,7 +780,7 @@ func (h *AgentClientWrapper) WriteFile(ctx context.Context, name string, data io
 			Data: &proto.WriteFileRequest_Metadata{
 				Metadata: &proto.FileMetadata{
 					Name: name,
-					Perm: perm,
+					Perm: uint32(perm),
 				},
 			},
 		},

--- a/host/lib/host.go
+++ b/host/lib/host.go
@@ -35,7 +35,7 @@ func SimpleRun(ctx context.Context, hst types.BaseHost, cmd types.Cmd) (types.Wa
 }
 
 // MkdirAll wraps Host.Mkdir and behavess similar to os.MkdirAll.
-func MkdirAll(ctx context.Context, hst types.Host, name string, mode uint32) error {
+func MkdirAll(ctx context.Context, hst types.Host, name string, mode types.FileMode) error {
 	stat_t, err := hst.Lstat(ctx, name)
 	if err == nil {
 		if stat_t.Mode&syscall.S_IFMT == syscall.S_IFDIR {

--- a/host/types/file.go
+++ b/host/types/file.go
@@ -1,6 +1,70 @@
 package types
 
-import "syscall"
+import (
+	"fmt"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+	"gopkg.in/yaml.v3"
+)
+
+// File mode bits 07777, see inode(7).
+type FileMode uint32
+
+func (f *FileMode) String() string {
+	if *f > 0 {
+		return fmt.Sprintf("0%o", *f)
+	}
+	return "0"
+}
+
+func (f *FileMode) MarshalYAML() (interface{}, error) {
+	return f.String(), nil
+}
+
+func (f *FileMode) UnmarshalYAML(value *yaml.Node) error {
+	var fileModeStr string
+	if err := value.Decode(&fileModeStr); err != nil {
+		return err
+	}
+	n, err := fmt.Sscanf(fileModeStr, "%o", f)
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return fmt.Errorf("invalid file mode: %#v", value.Value)
+	}
+	return nil
+}
+
+// Mask for all file mode bits.
+var FileModeBitsMask FileMode = 07777
+
+// File device dev_t, as expected by mknod(2).
+type FileDevice uint64
+
+func (f *FileDevice) String() string {
+	return fmt.Sprintf("%d,%d", unix.Major(uint64(*f)), unix.Minor(uint64(*f)))
+}
+
+func (f *FileDevice) MarshalYAML() (interface{}, error) {
+	return f.String(), nil
+}
+
+func (f *FileDevice) UnmarshalYAML(value *yaml.Node) error {
+	var fileDeviceStr string
+	if err := value.Decode(&fileDeviceStr); err != nil {
+		return err
+	}
+	n, err := fmt.Sscanf(fileDeviceStr, "%d:%d", f)
+	if err != nil {
+		return err
+	}
+	if n != 2 {
+		return fmt.Errorf("invalid file device: %#v", value.Value)
+	}
+	return nil
+}
 
 // Timespec from syscall.Timespec for Linux
 type Timespec struct {

--- a/host/types/host.go
+++ b/host/types/host.go
@@ -37,7 +37,7 @@ type Host interface {
 	Getegid(ctx context.Context) (uint64, error)
 
 	// Chmod works similar to syscall.Chmod.
-	Chmod(ctx context.Context, name string, mode uint32) error
+	Chmod(ctx context.Context, name string, mode FileMode) error
 
 	// Lchown works similar to syscall.Lchown.
 	Lchown(ctx context.Context, name string, uid, gid uint32) error
@@ -60,7 +60,7 @@ type Host interface {
 	ReadDir(ctx context.Context, name string) (dirEntResultCh <-chan DirEntResult, cancel func())
 
 	// Mkdir works similar to syscall.Mkdir, but ignoring umask.
-	Mkdir(ctx context.Context, name string, mode uint32) error
+	Mkdir(ctx context.Context, name string, mode FileMode) error
 
 	// ReadFile works similar to os.ReadFile.
 	ReadFile(ctx context.Context, name string) (io.ReadCloser, error)
@@ -75,10 +75,10 @@ type Host interface {
 	Remove(ctx context.Context, name string) error
 
 	// Mknod works similar to syscall.Mknod, but ignoring umask.
-	Mknod(ctx context.Context, path string, mode uint32, dev uint64) error
+	Mknod(ctx context.Context, path string, mode FileMode, dev FileDevice) error
 
 	// WriteFile works similar to os.WriteFile, but receives mode bits (see inode(7)) and ignores umask.
-	WriteFile(ctx context.Context, name string, data io.Reader, mode uint32) error
+	WriteFile(ctx context.Context, name string, data io.Reader, mode FileMode) error
 }
 
 // Run starts the specified command and waits for it to complete.
@@ -101,7 +101,7 @@ func Run(ctx context.Context, hst BaseHost, cmd Cmd) (WaitStatus, string, string
 }
 
 // MkdirAll wraps Host.Mkdir and behavess similar to os.MkdirAll.
-func MkdirAll(ctx context.Context, hst Host, name string, mode uint32) error {
+func MkdirAll(ctx context.Context, hst Host, name string, mode FileMode) error {
 	stat_t, err := hst.Lstat(ctx, name)
 	if err == nil {
 		if stat_t.Mode&syscall.S_IFMT == syscall.S_IFDIR {

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -30,13 +30,16 @@ func TestPlan(t *testing.T) {
 	// or not existing on the target / last blueprints, their states and
 	// the original state.
 	// Expectations are a function of the planned actions and the diff generated.
+	fileContentTarget := "target"
+	fileContentOriginal := "original"
+	fileContentLast := "last"
 	testCases := []testCase{
 		{
 			name: "target=exists,last=absent,original=absent",
 			targetResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "target",
+					Path:        "/foo",
+					RegularFile: &fileContentTarget,
 				},
 			},
 			lastResources: resourcesPkg.Resources{},
@@ -49,41 +52,41 @@ func TestPlan(t *testing.T) {
 			expectedPlan: `File:🔧/foo
   path: /foo
   -absent: true
-  +content: target`,
+  +regular_file: target`,
 		},
 		{
 			name: "target!=original,last=absent,original=exists",
 			targetResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "target",
+					Path:        "/foo",
+					RegularFile: &fileContentTarget,
 				},
 			},
 			lastResources: resourcesPkg.Resources{},
 			originalResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "original",
+					Path:        "/foo",
+					RegularFile: &fileContentOriginal,
 				},
 			},
 			expectedPlan: `File:🔄/foo
   path: /foo
-  -content: original
-  +content: target`,
+  -regular_file: original
+  +regular_file: target`,
 		},
 		{
 			name: "target=original,last=absent,original=exists",
 			targetResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "original",
+					Path:        "/foo",
+					RegularFile: &fileContentOriginal,
 				},
 			},
 			lastResources: resourcesPkg.Resources{},
 			originalResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "original",
+					Path:        "/foo",
+					RegularFile: &fileContentOriginal,
 				},
 			},
 			expectedPlan: `File:✅/foo`,
@@ -93,39 +96,39 @@ func TestPlan(t *testing.T) {
 			targetResources: resourcesPkg.Resources{},
 			lastResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "last",
+					Path:        "/foo",
+					RegularFile: &fileContentLast,
 				},
 			},
 			originalResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "original",
+					Path:        "/foo",
+					RegularFile: &fileContentOriginal,
 				},
 			},
 			expectedPlan: `File:🔄/foo
   path: /foo
-  -content: last
-  +content: original`,
+  -regular_file: last
+  +regular_file: original`,
 		},
 		{
 			name: "target=last,last=exists,original=exists",
 			targetResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "last",
+					Path:        "/foo",
+					RegularFile: &fileContentLast,
 				},
 			},
 			lastResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "last",
+					Path:        "/foo",
+					RegularFile: &fileContentLast,
 				},
 			},
 			originalResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "original",
+					Path:        "/foo",
+					RegularFile: &fileContentOriginal,
 				},
 			},
 			expectedPlan: `File:✅/foo`,
@@ -134,26 +137,26 @@ func TestPlan(t *testing.T) {
 			name: "target=!last,last=exists,original=exists",
 			targetResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "target",
+					Path:        "/foo",
+					RegularFile: &fileContentTarget,
 				},
 			},
 			lastResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "last",
+					Path:        "/foo",
+					RegularFile: &fileContentLast,
 				},
 			},
 			originalResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "original",
+					Path:        "/foo",
+					RegularFile: &fileContentOriginal,
 				},
 			},
 			expectedPlan: `File:🔄/foo
   path: /foo
-  -content: last
-  +content: target`,
+  -regular_file: last
+  +regular_file: target`,
 		},
 		{
 			name: "target=absent,last=exists,original=exists",
@@ -165,19 +168,19 @@ func TestPlan(t *testing.T) {
 			},
 			lastResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "last",
+					Path:        "/foo",
+					RegularFile: &fileContentLast,
 				},
 			},
 			originalResources: resourcesPkg.Resources{
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "original",
+					Path:        "/foo",
+					RegularFile: &fileContentOriginal,
 				},
 			},
 			expectedPlan: `File:🗑/foo
   path: /foo
-  -content: last
+  -regular_file: last
   +absent: true`,
 		},
 		{
@@ -188,12 +191,12 @@ func TestPlan(t *testing.T) {
 					Version: "3.5.target",
 				},
 				&resourcesPkg.File{
-					Path:    "/baz",
-					Content: "target",
+					Path:        "/baz",
+					RegularFile: &fileContentTarget,
 				},
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "target",
+					Path:        "/foo",
+					RegularFile: &fileContentTarget,
 				},
 			},
 			lastResources: resourcesPkg.Resources{
@@ -202,16 +205,16 @@ func TestPlan(t *testing.T) {
 					Version: "3.4.last",
 				},
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "last",
+					Path:        "/foo",
+					RegularFile: &fileContentLast,
 				},
 				&resourcesPkg.APTPackage{
 					Package: "fooPkg",
 					Version: "1.2.last",
 				},
 				&resourcesPkg.File{
-					Path:    "/bar",
-					Content: "last",
+					Path:        "/bar",
+					RegularFile: &fileContentLast,
 				},
 			},
 			originalResources: resourcesPkg.Resources{
@@ -220,20 +223,20 @@ func TestPlan(t *testing.T) {
 					Version: "3.4.original",
 				},
 				&resourcesPkg.File{
-					Path:    "/foo",
-					Content: "original",
+					Path:        "/foo",
+					RegularFile: &fileContentOriginal,
 				},
 				&resourcesPkg.APTPackage{
 					Package: "fooPkg",
 					Version: "1.2.original",
 				},
 				&resourcesPkg.File{
-					Path:    "/bar",
-					Content: "original",
+					Path:        "/bar",
+					RegularFile: &fileContentOriginal,
 				},
 				&resourcesPkg.File{
-					Path:    "/baz",
-					Content: "original",
+					Path:        "/baz",
+					RegularFile: &fileContentOriginal,
 				},
 			},
 			expectedPlan: `APTPackages:🔄barPkg,🔄fooPkg
@@ -247,16 +250,16 @@ func TestPlan(t *testing.T) {
     +version: 1.2.original
 File:🔄/baz
   path: /baz
-  -content: original
-  +content: target
+  -regular_file: original
+  +regular_file: target
 File:🔄/foo
   path: /foo
-  -content: last
-  +content: target
+  -regular_file: last
+  +regular_file: target
 File:🔄/bar
   path: /bar
-  -content: last
-  +content: original`,
+  -regular_file: last
+  +regular_file: original`,
 		},
 	}
 

--- a/resources/file.go
+++ b/resources/file.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -9,7 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
+	"strings"
+	"syscall"
 
 	"github.com/fornellas/resonance/host/types"
 )
@@ -20,52 +22,171 @@ type File struct {
 	Path string `yaml:"path"`
 	// Whether to remove the file
 	Absent bool `yaml:"absent,omitempty"`
-	// Contents of the file
-	Content string `yaml:"content,omitempty"`
-	// Mode bits
-	Mode uint32 `yaml:"mode,omitempty"`
-	// User ID owner of the file
-	Uid uint32 `yaml:"uid,omitempty"`
+	// Create a socket file
+	Socket bool `yaml:"socket,omitempty"`
+	// Create a symbolic link pointing to given path
+	SymbolicLink string `yaml:"symbolic_link,omitempty"`
+	// Create a regular file with given contents
+	RegularFile *string `yaml:"regular_file,omitempty"`
+	// Create a block device file with given majon / minor.
+	BlockDevice *types.FileDevice `yaml:"block_device,omitempty"`
+	// Create a directory with given contents
+	Directory *[]File `yaml:"directory,omitempty"`
+	// Create a character device file with given majon / minor
+	CharacterDevice *types.FileDevice `yaml:"character_device,omitempty"`
+	// Create a FIFO file
+	FIFO bool `yaml:"FIFO,omitempty"`
+	// Mode bits 07777, see inode(7).
+	Mode *types.FileMode `yaml:"mode,omitempty"`
+	// User ID owner of the file. Default: 0.
+	Uid *uint32 `yaml:"uid,omitempty"`
 	// User name owner of the file
-	User string `yaml:"user,omitempty"`
-	// Group ID owner of the file
-	Gid uint32 `yaml:"gid,omitempty"`
+	User *string `yaml:"user,omitempty"`
+	// Group ID owner of the file. Default: 0.
+	Gid *uint32 `yaml:"gid,omitempty"`
 	// Group name owner of the file
-	Group string `yaml:"group,omitempty"`
+	Group *string `yaml:"group,omitempty"`
 }
 
-func (f *File) Validate() error {
+func (f *File) validatePath() error {
 	if f.Path == "" {
 		return fmt.Errorf("'path' must be set")
 	}
 
-	if !filepath.IsAbs(string(f.Path)) {
-		return fmt.Errorf("'path' must be absolute")
+	if !filepath.IsAbs(f.Path) {
+		return fmt.Errorf("'path' must be absolute: %#v", f.Path)
 	}
 
-	if f.Uid != 0 && f.User != "" {
-		return fmt.Errorf("can't set both 'uid' and 'user'")
-	}
-
-	if f.Gid != 0 && f.Group != "" {
-		return fmt.Errorf("can't set both 'gid' and 'group'")
+	cleanPath := filepath.Clean(f.Path)
+	if cleanPath != f.Path {
+		return fmt.Errorf("'path' must be clean: %#v should be %#v", f.Path, cleanPath)
 	}
 
 	return nil
 }
 
-func (f *File) Load(ctx context.Context, hst types.Host) error {
-	*f = File{
-		Path: f.Path,
+func (f *File) validateAbsentAndType() error {
+	fileTypes := []bool{
+		f.Socket,
+		f.SymbolicLink != "",
+		f.RegularFile != nil,
+		f.BlockDevice != nil,
+		f.Directory != nil,
+		f.CharacterDevice != nil,
+		f.FIFO,
 	}
 
-	// Content
+	typeCount := 0
+	for _, isSet := range fileTypes {
+		if isSet {
+			typeCount++
+		}
+	}
+
+	if typeCount == 0 {
+		if f.Absent {
+			if f.Mode != nil {
+				return fmt.Errorf("can not set 'mode' with absent")
+			}
+			if f.Uid != nil {
+				return fmt.Errorf("can not set 'uid' with absent")
+			}
+			if f.User != nil {
+				return fmt.Errorf("can not set 'user' with absent")
+			}
+			if f.Gid != nil {
+				return fmt.Errorf("can not set 'gid' with absent")
+			}
+			if f.Group != nil {
+				return fmt.Errorf("can not set 'group' with absent")
+			}
+		} else {
+			return fmt.Errorf("one file type must be defined without 'absent'")
+		}
+	} else if typeCount == 1 {
+		if f.Absent {
+			return fmt.Errorf("can not set 'absent' and a file type at the same time")
+		}
+	} else {
+		return fmt.Errorf("only one file type can be defined")
+	}
+
+	return nil
+}
+
+func (f *File) validateDirectory() error {
+	if f.Directory != nil {
+		for _, subFile := range *f.Directory {
+			if filepath.Dir(subFile.Path) != f.Path {
+				return fmt.Errorf("directory entry '%s' is not a subpath of '%s'", subFile.Path, f.Path)
+			}
+			if err := subFile.Validate(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *File) validateMode() error {
+	if f.Mode != nil {
+		if *f.Mode&(^types.FileModeBitsMask) > 0 {
+			return fmt.Errorf("file mode does not match mask %#o: %#o", types.FileModeBitsMask, *f.Mode)
+		}
+	}
+	return nil
+}
+
+func (f *File) Validate() error {
+	// Path
+	if err := f.validatePath(); err != nil {
+		return err
+	}
+
+	// Absent / Type
+	if err := f.validateAbsentAndType(); err != nil {
+		return err
+	}
+
+	// SymbolicLink
+	if len(f.SymbolicLink) != 0 && f.Mode != nil {
+		return fmt.Errorf("can not set 'mode' with symlink")
+	}
+
+	// Directory
+	if err := f.validateDirectory(); err != nil {
+		return err
+	}
+
+	// Mode
+	if err := f.validateMode(); err != nil {
+		return err
+	}
+
+	if f.Uid != nil && f.User != nil {
+		return fmt.Errorf("can't set both 'uid' and 'user': %d, %#v", *f.Uid, *f.User)
+	}
+
+	if f.Gid != nil && f.Group != nil {
+		return fmt.Errorf("can't set both 'gid' and 'group': %d, %#v", *f.Gid, *f.Group)
+	}
+
+	return nil
+}
+
+func (f *File) loadSymbolicLink(ctx context.Context, hst types.Host) error {
+	target, err := hst.Readlink(ctx, f.Path)
+	if err != nil {
+		return err
+	}
+	f.SymbolicLink = target
+	f.Mode = nil
+	return nil
+}
+
+func (f *File) loadRegularFile(ctx context.Context, hst types.Host) error {
 	fileReadCloser, err := hst.ReadFile(ctx, string(f.Path))
 	if err != nil {
-		if os.IsNotExist(err) {
-			f.Absent = true
-			return nil
-		}
 		return err
 	}
 	contentBytes, err := io.ReadAll(fileReadCloser)
@@ -78,29 +199,97 @@ func (f *File) Load(ctx context.Context, hst types.Host) error {
 	if err := fileReadCloser.Close(); err != nil {
 		return err
 	}
-	f.Content = string(contentBytes)
+	f.RegularFile = new(string)
+	*f.RegularFile = string(contentBytes)
+	return nil
+}
 
-	// FileInfo
+func (f *File) loadDirectory(ctx context.Context, hst types.Host) error {
+	dirEntResultCh, cancel := hst.ReadDir(ctx, f.Path)
+	defer cancel()
+
+	directory := []File{}
+	f.Directory = &directory
+	for dirEntResult := range dirEntResultCh {
+		if dirEntResult.Error != nil {
+			return dirEntResult.Error
+		}
+		subFile := File{Path: filepath.Join(f.Path, dirEntResult.DirEnt.Name)}
+		if err := subFile.Load(ctx, hst); err != nil {
+			return err
+		}
+		directory = append(directory, subFile)
+	}
+
+	sort.SliceStable(directory, func(i, j int) bool {
+		return directory[i].Path < directory[j].Path
+	})
+
+	return nil
+}
+
+func (f *File) Load(ctx context.Context, hst types.Host) error {
+	*f = File{
+		Path: f.Path,
+	}
+
 	stat_t, err := hst.Lstat(ctx, string(f.Path))
 	if err != nil {
+		if os.IsNotExist(err) {
+			f.Absent = true
+			return nil
+		}
 		return err
 	}
 
-	// Perm
-	f.Mode = stat_t.Mode & 07777
+	var mode types.FileMode = types.FileMode(stat_t.Mode) & types.FileModeBitsMask
+	f.Mode = &mode
+	f.Uid = &stat_t.Uid
+	f.Gid = &stat_t.Gid
 
-	// Uid
-	f.Uid = stat_t.Uid
-
-	// Gid
-	f.Gid = stat_t.Gid
+	switch stat_t.Mode & syscall.S_IFMT {
+	case syscall.S_IFSOCK:
+		f.Socket = true
+	case syscall.S_IFLNK:
+		if err := f.loadSymbolicLink(ctx, hst); err != nil {
+			return err
+		}
+	case syscall.S_IFREG:
+		if err := f.loadRegularFile(ctx, hst); err != nil {
+			return err
+		}
+	case syscall.S_IFBLK:
+		f.BlockDevice = (*types.FileDevice)(&stat_t.Rdev)
+	case syscall.S_IFDIR:
+		if err := f.loadDirectory(ctx, hst); err != nil {
+			return err
+		}
+	case syscall.S_IFCHR:
+		f.CharacterDevice = (*types.FileDevice)(&stat_t.Rdev)
+	case syscall.S_IFIFO:
+		f.FIFO = true
+	default:
+		panic(fmt.Sprintf("bug: unexpected stat_t.Mode: 0x%x", stat_t.Mode))
+	}
 
 	return nil
 }
 
 func (f *File) Resolve(ctx context.Context, hst types.Host) error {
-	if f.User != "" {
-		usr, err := hst.Lookup(ctx, f.User)
+	if f.Directory != nil {
+		sort.SliceStable(*f.Directory, func(i int, j int) bool {
+			return (*f.Directory)[i].Path < (*f.Directory)[j].Path
+		})
+		for i, subFile := range *f.Directory {
+			if err := subFile.Resolve(ctx, hst); err != nil {
+				return err
+			}
+			(*f.Directory)[i] = subFile
+		}
+	}
+
+	if f.User != nil {
+		usr, err := hst.Lookup(ctx, *f.User)
 		if err != nil {
 			return err
 		}
@@ -108,12 +297,16 @@ func (f *File) Resolve(ctx context.Context, hst types.Host) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse UID: %s", usr.Uid)
 		}
-		f.Uid = uint32(uid)
-		f.User = ""
+		uid32 := uint32(uid)
+		f.Uid = &uid32
+		f.User = nil
+	}
+	if f.Uid == nil {
+		f.Uid = new(uint32)
 	}
 
-	if f.Group != "" {
-		group, err := hst.LookupGroup(ctx, f.Group)
+	if f.Group != nil {
+		group, err := hst.LookupGroup(ctx, *f.Group)
 		if err != nil {
 			return err
 		}
@@ -121,44 +314,217 @@ func (f *File) Resolve(ctx context.Context, hst types.Host) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse GID: %s", group.Gid)
 		}
-		f.Gid = uint32(gid)
-		f.Group = ""
+		gid32 := uint32(gid)
+		f.Gid = &gid32
+		f.Group = nil
+	}
+	if f.Gid == nil {
+		f.Gid = new(uint32)
 	}
 
 	return nil
 }
 
-func (f *File) Apply(ctx context.Context, hst types.Host) error {
-	// Remove
-	if f.Absent {
-		err := hst.Remove(ctx, string(f.Path))
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	// Content
-	if err := hst.WriteFile(ctx, string(f.Path), bytes.NewReader([]byte(f.Content)), f.Mode); err != nil {
-		return err
-	}
-
-	// Perm
-	if err := hst.Chmod(ctx, string(f.Path), f.Mode); err != nil {
-		return err
-	}
-
-	// FileInfo
-	fileInfo, err := hst.Lstat(ctx, string(f.Path))
+func (f *File) removeRecursively(ctx context.Context, hst types.Host) error {
+	err := hst.Remove(ctx, f.Path)
 	if err != nil {
-		return err
-	}
-
-	// Uid / Gid
-	if fileInfo.Uid != f.Uid || fileInfo.Gid != f.Gid {
-		if err := hst.Lchown(ctx, string(f.Path), f.Uid, f.Gid); err != nil {
+		var errno syscall.Errno
+		if errors.As(err, &errno) {
+			switch errno {
+			case syscall.ENOENT:
+				return nil
+			case syscall.ENOTEMPTY:
+				break
+			default:
+				return err
+			}
+		} else {
 			return err
 		}
+	}
+
+	dirEntResultCh, cancel := hst.ReadDir(ctx, f.Path)
+	defer cancel()
+	for dirEntResult := range dirEntResultCh {
+		if dirEntResult.Error != nil {
+			return err
+		}
+		subFile := File{Path: filepath.Join(f.Path, dirEntResult.DirEnt.Name), Absent: true}
+		if err := subFile.Apply(ctx, hst); err != nil {
+			return err
+		}
+	}
+
+	return hst.Remove(ctx, f.Path)
+}
+
+func (f *File) applySocket(ctx context.Context, hst types.Host, currentFile *File) error {
+	if f.Socket {
+		if !currentFile.Socket {
+			if err := currentFile.removeRecursively(ctx, hst); err != nil {
+				return err
+			}
+			if err := hst.Mknod(ctx, f.Path, *f.Mode|syscall.S_IFSOCK, 0); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *File) applySymbolicLink(ctx context.Context, hst types.Host, currentFile *File) error {
+	if f.SymbolicLink != "" {
+		if currentFile.SymbolicLink != f.SymbolicLink {
+			if err := currentFile.removeRecursively(ctx, hst); err != nil {
+				return err
+			}
+			if err := hst.Symlink(ctx, f.SymbolicLink, f.Path); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *File) applyRegularFile(ctx context.Context, hst types.Host, currentFile *File) error {
+	if f.RegularFile != nil {
+		if currentFile.RegularFile == nil || *currentFile.RegularFile != *f.RegularFile {
+			if err := currentFile.removeRecursively(ctx, hst); err != nil {
+				return err
+			}
+			if err := hst.WriteFile(ctx, string(f.Path), strings.NewReader(*f.RegularFile), *f.Mode); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *File) applyBlockDevice(ctx context.Context, hst types.Host, currentFile *File) error {
+	if f.BlockDevice != nil {
+		if currentFile.BlockDevice == nil || *currentFile.BlockDevice != *f.BlockDevice {
+			if err := currentFile.removeRecursively(ctx, hst); err != nil {
+				return err
+			}
+			if err := hst.Mknod(ctx, f.Path, *f.Mode|syscall.S_IFBLK, *f.BlockDevice); err != nil {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+func (f *File) applyDirectory(ctx context.Context, hst types.Host, currentFile *File) error {
+	if f.Directory != nil {
+		if currentFile.Directory == nil {
+			if err := currentFile.removeRecursively(ctx, hst); err != nil {
+				return err
+			}
+			if err := hst.Mkdir(ctx, f.Path, *f.Mode); err != nil {
+				return err
+			}
+		}
+		pathToDelete := map[string]bool{}
+		if currentFile.Directory != nil {
+			for _, subFile := range *currentFile.Directory {
+				pathToDelete[subFile.Path] = true
+			}
+		}
+		for _, subFile := range *f.Directory {
+			if err := subFile.Apply(ctx, hst); err != nil {
+				return err
+			}
+			delete(pathToDelete, subFile.Path)
+		}
+		for path := range pathToDelete {
+			file := File{
+				Path:   path,
+				Absent: true,
+			}
+			if err := file.Apply(ctx, hst); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *File) applyCharacterDevice(ctx context.Context, hst types.Host, currentFile *File) error {
+	if f.CharacterDevice != nil {
+		if currentFile.CharacterDevice == nil || *currentFile.CharacterDevice != *f.CharacterDevice {
+			if err := currentFile.removeRecursively(ctx, hst); err != nil {
+				return err
+			}
+			if err := hst.Mknod(ctx, f.Path, *f.Mode|syscall.S_IFCHR, *f.CharacterDevice); err != nil {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+func (f *File) applyFIFO(ctx context.Context, hst types.Host, currentFile *File) error {
+	if f.FIFO {
+		if !currentFile.FIFO {
+			if err := currentFile.removeRecursively(ctx, hst); err != nil {
+				return err
+			}
+			if err := hst.Mknod(ctx, f.Path, *f.Mode|syscall.S_IFIFO, 0); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *File) Apply(ctx context.Context, hst types.Host) error {
+	currentFile := &File{
+		Path: f.Path,
+	}
+	if err := currentFile.Load(ctx, hst); err != nil {
+		return err
+	}
+
+	if f.Absent {
+		return currentFile.removeRecursively(ctx, hst)
+	}
+
+	if err := f.applySocket(ctx, hst, currentFile); err != nil {
+		return err
+	}
+
+	if err := f.applySymbolicLink(ctx, hst, currentFile); err != nil {
+		return err
+	}
+
+	if err := f.applyRegularFile(ctx, hst, currentFile); err != nil {
+		return err
+	}
+
+	if err := f.applyBlockDevice(ctx, hst, currentFile); err != nil {
+		return err
+	}
+
+	if err := f.applyDirectory(ctx, hst, currentFile); err != nil {
+		return err
+	}
+
+	if err := f.applyCharacterDevice(ctx, hst, currentFile); err != nil {
+		return err
+	}
+
+	if err := f.applyFIFO(ctx, hst, currentFile); err != nil {
+		return err
+	}
+
+	if f.Mode != nil {
+		if err := hst.Chmod(ctx, f.Path, *f.Mode); err != nil {
+			return err
+		}
+	}
+
+	if err := hst.Lchown(ctx, f.Path, *f.Uid, *f.Gid); err != nil {
+		return err
 	}
 
 	return nil

--- a/resources/file_linux_test.go
+++ b/resources/file_linux_test.go
@@ -1,0 +1,647 @@
+package resources
+
+import (
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+	"reflect"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/fornellas/resonance/diff"
+	"github.com/fornellas/resonance/host"
+	"github.com/fornellas/resonance/host/types"
+	"github.com/fornellas/resonance/log"
+)
+
+type FileTestCase struct {
+	Title         string
+	File          File
+	ErrorContains string
+}
+
+func (f *FileTestCase) Run(t *testing.T) {
+	t.Run(f.Title, func(t *testing.T) {
+		err := f.File.Validate()
+		if f.ErrorContains != "" {
+			require.ErrorContains(t, err, f.ErrorContains)
+		} else {
+			require.NoError(t, err)
+		}
+	})
+}
+
+func isRoot(t *testing.T) bool {
+	u, err := user.Current()
+	require.NoError(t, err)
+	return u.Uid == "0"
+}
+
+func TestFile(t *testing.T) {
+	ctx := context.Background()
+	ctx = log.WithTestLogger(ctx)
+	hst := host.Local{}
+
+	user := "user"
+	var uid uint32 = uint32(os.Getuid())
+	group := "group"
+	var gid uint32 = uint32(os.Getgid())
+	var mode types.FileMode = 01724
+	var badMode types.FileMode = 07777 + 1
+	contents := "foo\nbar"
+	var device types.FileDevice = 234122345
+
+	t.Run("Validate()", func(t *testing.T) {
+		for _, tc := range []FileTestCase{
+			// Path
+			{
+				Title: "valid path",
+				File: File{
+					Path:   "/foo",
+					Absent: true,
+				},
+			},
+			{
+				Title: "relative path",
+				File: File{
+					Path:   "foo",
+					Absent: true,
+				},
+				ErrorContains: "'path' must be absolute",
+			},
+			{
+				Title: "not clean path",
+				File: File{
+					Path:   "//foo",
+					Absent: true,
+				},
+				ErrorContains: "'path' must be clean",
+			},
+			// Absent / Type
+			{
+				Title: "absent",
+				File: File{
+					Path:   "/foo",
+					Absent: true,
+				},
+			},
+			{
+				Title: "absent with mode",
+				File: File{
+					Path:   "/foo",
+					Absent: true,
+					Mode:   &mode,
+				},
+				ErrorContains: "can not set 'mode' with absent",
+			},
+			{
+				Title: "absent with uid",
+				File: File{
+					Path:   "/foo",
+					Absent: true,
+					Uid:    &uid,
+				},
+				ErrorContains: "can not set 'uid' with absent",
+			},
+			{
+				Title: "absent with user",
+				File: File{
+					Path:   "/foo",
+					Absent: true,
+					User:   &user,
+				},
+				ErrorContains: "can not set 'user' with absent",
+			},
+			{
+				Title: "absent with gid",
+				File: File{
+					Path:   "/foo",
+					Absent: true,
+					Gid:    &gid,
+				},
+				ErrorContains: "can not set 'gid' with absent",
+			},
+			{
+				Title: "absent with group",
+				File: File{
+					Path:   "/foo",
+					Absent: true,
+					Group:  &group,
+				},
+				ErrorContains: "can not set 'group' with absent",
+			},
+			{
+				Title: "absent with type definition",
+				File: File{
+					Path:         "/foo",
+					Absent:       true,
+					SymbolicLink: "/bar",
+				},
+				ErrorContains: "can not set 'absent' and a file type at the same time",
+			},
+			{
+				Title: "multiple types",
+				File: File{
+					Path:   "/foo",
+					FIFO:   true,
+					Socket: true,
+				},
+				ErrorContains: "only one file type can be defined",
+			},
+			// Socket
+			{
+				Title: "socket",
+				File: File{
+					Path:   "/foo",
+					Socket: true,
+				},
+			},
+			// SymbolicLink
+			{
+				Title: "symlink",
+				File: File{
+					Path:         "/foo",
+					SymbolicLink: "/bar",
+				},
+			},
+			{
+				Title: "symlink with mode",
+				File: File{
+					Path:         "/foo",
+					SymbolicLink: "/bar",
+					Mode:         &mode,
+				},
+				ErrorContains: "can not set 'mode' with symlink",
+			},
+			// RegularFile
+			{
+				Title: "regular file",
+				File: File{
+					Path:        "/foo",
+					RegularFile: new(string),
+				},
+			},
+			// BlockDevice
+			{
+				Title: "block device",
+				File: File{
+					Path:        "/foo",
+					BlockDevice: &device,
+				},
+			},
+			// Directory
+			{
+				Title: "directory",
+				File: File{
+					Path: "/foo",
+					Directory: &[]File{
+						{
+							Path:        "/foo/bar",
+							RegularFile: new(string),
+						},
+					},
+				},
+			},
+			{
+				Title: "directory entry not subpath",
+				File: File{
+					Path: "/foo",
+					Directory: &[]File{
+						{
+							Path:        "/fooz/bar",
+							RegularFile: new(string),
+						},
+					},
+				},
+				ErrorContains: "is not a subpath",
+			},
+			// CharacterDevice
+			{
+				Title: "char device",
+				File: File{
+					Path:            "/foo",
+					CharacterDevice: &device,
+				},
+			},
+			// FIFO
+			{
+				Title: "fifo",
+				File: File{
+					Path: "/foo",
+					FIFO: true,
+				},
+			},
+			// Mode
+			{
+				Title: "invalid mode",
+				File: File{
+					Path:        "/foo",
+					RegularFile: new(string),
+					Mode:        &badMode,
+				},
+				ErrorContains: "file mode does not match mask",
+			},
+			// Uid / User
+			{
+				Title: "uid",
+				File: File{
+					Path:        "/foo",
+					RegularFile: new(string),
+					Uid:         new(uint32),
+				},
+			},
+			{
+				Title: "user",
+				File: File{
+					Path:        "/foo",
+					RegularFile: new(string),
+					User:        &user,
+				},
+			},
+			{
+				Title: "uid + user",
+				File: File{
+					Path:        "/foo",
+					RegularFile: new(string),
+					Uid:         new(uint32),
+					User:        &user,
+				},
+				ErrorContains: "can't set both 'uid' and 'user'",
+			},
+			// Gid / Group
+			{
+				Title: "gid",
+				File: File{
+					Path:        "/foo",
+					RegularFile: new(string),
+					Gid:         new(uint32),
+				},
+			},
+			{
+				Title: "group",
+				File: File{
+					Path:        "/foo",
+					RegularFile: new(string),
+					Group:       &group,
+				},
+			},
+			{
+				Title: "gid	+ group",
+				File: File{
+					Path:        "/foo",
+					RegularFile: new(string),
+					Gid:         new(uint32),
+					Group:       &group,
+				},
+				ErrorContains: "can't set both 'gid' and 'group'",
+			},
+		} {
+			tc.Run(t)
+		}
+	})
+
+	t.Run("Load()", func(t *testing.T) {
+		t.Run("existing", func(t *testing.T) {
+			prefix := t.TempDir()
+			require.NoError(t, syscall.Chmod(prefix, uint32(mode)))
+
+			socketPath := filepath.Join(prefix, "socket")
+			require.NoError(t, syscall.Mknod(socketPath, syscall.S_IFSOCK, 0))
+			require.NoError(t, syscall.Chmod(socketPath, uint32(mode)))
+
+			symlinkPath := filepath.Join(prefix, "symlink")
+			symlinkOldPath := "target"
+			require.NoError(t, syscall.Symlink(symlinkOldPath, symlinkPath))
+
+			regularPath := filepath.Join(prefix, "regular")
+			require.NoError(t, os.WriteFile(regularPath, []byte(contents), os.FileMode(mode)))
+			require.NoError(t, syscall.Chmod(regularPath, uint32(mode)))
+
+			blockPath := filepath.Join(prefix, "block")
+			characterPath := filepath.Join(prefix, "character")
+			if isRoot(t) {
+				require.NoError(t, syscall.Mknod(blockPath, syscall.S_IFBLK|uint32(mode), int(device)))
+				require.NoError(t, syscall.Chmod(blockPath, uint32(mode)))
+
+				require.NoError(t, syscall.Mknod(characterPath, syscall.S_IFCHR|uint32(mode), int(device)))
+				require.NoError(t, syscall.Chmod(characterPath, uint32(mode)))
+			}
+
+			fifoPath := filepath.Join(prefix, "fifo")
+			require.NoError(t, syscall.Mknod(fifoPath, syscall.S_IFIFO|uint32(mode), 0))
+			require.NoError(t, syscall.Chmod(fifoPath, uint32(mode)))
+
+			file := File{Path: prefix}
+			require.NoError(t, file.Load(ctx, hst))
+
+			expectedFile := File{
+				Path: prefix,
+				Directory: &[]File{
+					{
+						Path: fifoPath,
+						FIFO: true,
+						Mode: &mode,
+						Uid:  &uid,
+						Gid:  &gid,
+					},
+					{
+						Path:        regularPath,
+						RegularFile: &contents,
+						Mode:        &mode,
+						Uid:         &uid,
+						Gid:         &gid,
+					},
+					{
+						Path:   socketPath,
+						Socket: true,
+						Mode:   &mode,
+						Uid:    &uid,
+						Gid:    &gid,
+					},
+					{
+						Path:         symlinkPath,
+						SymbolicLink: symlinkOldPath,
+						Uid:          &uid,
+						Gid:          &gid,
+					},
+				},
+				Mode: &mode,
+				Uid:  &uid,
+				Gid:  &gid,
+			}
+
+			if isRoot(t) {
+				*expectedFile.Directory = append(
+					[]File{
+						{
+							Path:        blockPath,
+							BlockDevice: &device,
+							Mode:        &mode,
+							Uid:         &uid,
+							Gid:         &gid,
+						},
+						{
+							Path:            characterPath,
+							CharacterDevice: &device,
+							Mode:            &mode,
+							Uid:             &uid,
+							Gid:             &gid,
+						},
+					},
+					*expectedFile.Directory...,
+				)
+			}
+
+			require.Truef(
+				t,
+				reflect.DeepEqual(expectedFile, file),
+				diff.DiffAsYaml(expectedFile, file).String(),
+			)
+		})
+		t.Run("absent", func(t *testing.T) {
+			prefix := t.TempDir()
+			path := filepath.Join(prefix, "absent")
+			file := File{Path: path}
+			err := file.Load(ctx, hst)
+			require.NoError(t, err)
+			require.True(t, reflect.DeepEqual(file, File{
+				Path:   path,
+				Absent: true,
+			}))
+		})
+	})
+
+	t.Run("Resolve()", func(t *testing.T) {
+		path := "/foo"
+		var uid uint32 = 0
+		var defaultUid uint32 = 0
+		var gid uint32 = 0
+		var defaultGid uint32 = 0
+		t.Run("User", func(t *testing.T) {
+			user := "root"
+			t.Run("valid", func(t *testing.T) {
+				file := File{
+					Path: path,
+					User: &user,
+				}
+				require.NoError(t, file.Resolve(ctx, hst))
+				expectedFile := File{
+					Path: path,
+					Uid:  &uid,
+					Gid:  &defaultGid,
+				}
+				require.Truef(
+					t,
+					reflect.DeepEqual(expectedFile, file),
+					diff.DiffAsYaml(expectedFile, file).String(),
+				)
+			})
+			t.Run("invalid", func(t *testing.T) {
+				badUser := "foobar"
+				file := File{
+					Path: path,
+					User: &badUser,
+				}
+				require.ErrorContains(t, file.Resolve(ctx, hst), "unknown user")
+			})
+		})
+		t.Run("Group", func(t *testing.T) {
+			group := "root"
+			t.Run("valid", func(t *testing.T) {
+				file := File{
+					Path:  path,
+					Group: &group,
+				}
+				require.NoError(t, file.Resolve(ctx, hst))
+				expectedFile := File{
+					Path: path,
+					Uid:  &defaultUid,
+					Gid:  &gid,
+				}
+				require.Truef(
+					t,
+					reflect.DeepEqual(expectedFile, file),
+					diff.DiffAsYaml(expectedFile, file).String(),
+				)
+			})
+			t.Run("invalid", func(t *testing.T) {
+				badGroup := "foobar"
+				file := File{
+					Path:  path,
+					Group: &badGroup,
+				}
+				require.ErrorContains(t, file.Resolve(ctx, hst), "unknown group")
+			})
+		})
+		t.Run("Directory", func(t *testing.T) {
+			t.Run("sort & recursion", func(t *testing.T) {
+				file := File{
+					Path: path,
+					Directory: &[]File{
+						{
+							Path:        filepath.Join(path, "last"),
+							RegularFile: new(string),
+						},
+						{
+							Path:        filepath.Join(path, "first"),
+							RegularFile: new(string),
+						},
+					},
+				}
+				require.NoError(t, file.Resolve(ctx, hst))
+				expectedFile := File{
+					Path: path,
+					Directory: &[]File{
+						{
+							Path:        filepath.Join(path, "first"),
+							RegularFile: new(string),
+							Uid:         &defaultUid,
+							Gid:         &defaultGid,
+						},
+						{
+							Path:        filepath.Join(path, "last"),
+							RegularFile: new(string),
+							Uid:         &defaultUid,
+							Gid:         &defaultGid,
+						},
+					},
+					Uid: &defaultUid,
+					Gid: &defaultGid,
+				}
+				require.Truef(
+					t,
+					reflect.DeepEqual(expectedFile, file),
+					diff.DiffAsYaml(expectedFile, file).String(),
+				)
+			})
+		})
+	})
+
+	t.Run("Apply()", func(t *testing.T) {
+		testApplyFn := func(prefix string, expectedErr error) {
+			socketPath := filepath.Join(prefix, "socket")
+			symlinkPath := filepath.Join(prefix, "symlink")
+			symlinkOldPath := "target"
+			regularPath := filepath.Join(prefix, "regular")
+			blockPath := filepath.Join(prefix, "block")
+			characterPath := filepath.Join(prefix, "character")
+			fifoPath := filepath.Join(prefix, "fifo")
+
+			file := File{
+				Path: prefix,
+				Directory: &[]File{
+					{
+						Path: fifoPath,
+						FIFO: true,
+						Mode: &mode,
+						Uid:  &uid,
+						Gid:  &gid,
+					},
+					{
+						Path:        regularPath,
+						RegularFile: &contents,
+						Mode:        &mode,
+						Uid:         &uid,
+						Gid:         &gid,
+					},
+					{
+						Path:   socketPath,
+						Socket: true,
+						Mode:   &mode,
+						Uid:    &uid,
+						Gid:    &gid,
+					},
+					{
+						Path:         symlinkPath,
+						SymbolicLink: symlinkOldPath,
+						Uid:          &uid,
+						Gid:          &gid,
+					},
+				},
+				Mode: &mode,
+				Uid:  &uid,
+				Gid:  &gid,
+			}
+
+			if isRoot(t) {
+				*file.Directory = append(
+					[]File{
+						{
+							Path:        blockPath,
+							BlockDevice: &device,
+							Mode:        &mode,
+							Uid:         &uid,
+							Gid:         &gid,
+						},
+						{
+							Path:            characterPath,
+							CharacterDevice: &device,
+							Mode:            &mode,
+							Uid:             &uid,
+							Gid:             &gid,
+						},
+					},
+					*file.Directory...,
+				)
+			}
+
+			err := file.Apply(ctx, hst)
+			if expectedErr == nil {
+				require.NoError(t, err)
+
+				loadedFile := File{Path: prefix}
+				require.NoError(t, loadedFile.Load(ctx, hst))
+
+				require.Truef(
+					t,
+					reflect.DeepEqual(file, loadedFile),
+					diff.DiffAsYaml(file, loadedFile).String(),
+				)
+			} else {
+				require.ErrorIs(t, err, expectedErr)
+			}
+		}
+		t.Run("initial condition: absent", func(t *testing.T) {
+			prefix := t.TempDir()
+			require.NoError(t, os.Remove(prefix))
+			testApplyFn(prefix, nil)
+		})
+		t.Run("initial condition: empty dir", func(t *testing.T) {
+			prefix := t.TempDir()
+			testApplyFn(prefix, nil)
+		})
+		t.Run("initial condition: different type", func(t *testing.T) {
+			prefix := t.TempDir()
+			require.NoError(t, os.Remove(prefix))
+			file, err := os.Create(prefix)
+			require.NoError(t, err)
+			require.NoError(t, file.Close())
+			testApplyFn(prefix, nil)
+		})
+		t.Run("initial condition: extra files in dir", func(t *testing.T) {
+			prefix := t.TempDir()
+
+			extraDirPath := filepath.Join(prefix, "extra_dir")
+			require.NoError(t, os.Mkdir(extraDirPath, os.FileMode(0755)))
+
+			extraFilePath := filepath.Join(extraDirPath, "extra_file")
+			file, err := os.Create(extraFilePath)
+			require.NoError(t, err)
+			require.NoError(t, file.Close())
+
+			testApplyFn(prefix, nil)
+		})
+		t.Run("initial condition: user has no permission to write", func(t *testing.T) {
+			prefix := t.TempDir()
+			require.NoError(t, os.Remove(prefix))
+			file, err := os.Create(prefix)
+			require.NoError(t, err)
+			require.NoError(t, file.Close())
+			require.NoError(t, os.Chmod(prefix, os.FileMode(0500)))
+			testApplyFn(prefix, nil)
+		})
+	})
+}

--- a/store/common_linux_test.go
+++ b/store/common_linux_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 func getTestBlueprint(t *testing.T, ctx context.Context) *blueprintPkg.Blueprint {
+	uid := uint32(123)
+	gid := uint32(456)
 	resources := resourcesPkg.Resources{
 		&resourcesPkg.File{
 			Path: "/tmp/foo",
-			Uid:  123,
-			Gid:  456,
+			Uid:  &uid,
+			Gid:  &gid,
 		},
 		&resourcesPkg.APTPackage{
 			Package: "foo",
@@ -44,11 +46,13 @@ func testStore(t *testing.T, store Store) {
 	}
 
 	t.Run("OriginalResource", func(t *testing.T) {
+		uid := uint32(123)
+		gid := uint32(456)
 		resources := resourcesPkg.Resources{
 			&resourcesPkg.File{
 				Path: "/tmp/foo",
-				Uid:  123,
-				Gid:  456,
+				Uid:  &uid,
+				Gid:  &gid,
 			},
 			&resourcesPkg.APTPackage{
 				Package: "foo",


### PR DESCRIPTION
ATM File is pretty basic, and can't handle all diverse cases.

This PR implements support for all file types, so it can actually manage anything.

It also adds `FileMode` type, making it easier to handle file permissions in octal.

---

**Stack**:
- #159
- #209
- #208 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*