### PR TITLE
Fix client freeze on agent crash

### DIFF
--- a/internal/host/agent_client_wrapper.go
+++ b/internal/host/agent_client_wrapper.go
@@ -285,13 +285,21 @@ func (h *AgentClientWrapper) spawn(ctx context.Context) error {
 				Logger: logger,
 			},
 		})
+
 		var waitStatusErr error
 		if !waitStatus.Success() {
 			waitStatusErr = errors.New(waitStatus.String())
 		}
+
+		stdinReaderErr := stdinReader.Close()
+
+		stdoutWriterErr := stdoutWriter.Close()
+
 		h.spawnErrCh <- errors.Join(
 			runErr,
 			waitStatusErr,
+			stdinReaderErr,
+			stdoutWriterErr,
 		)
 	}()
 


### PR DESCRIPTION
In cases where the agent crashes, the agent client will still be fully operational, attempting to read from the pipes, thus hanging forever.

This PR ensures that after the agent exists, we close the associated pipes, thus ensuring the client reading / writing from them can properly exit.

---

**Stack**:
- #159
- #209
- #208
- #215
- #216
- #202
- #211
- #214
- #212
- #204
- #213 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*