### PR TITLE
Add tests for Docker

### DIFF
--- a/host/types.go
+++ b/host/types.go
@@ -7,6 +7,13 @@ import (
 	"syscall"
 )
 
+var DefaultPath = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+var DefaultEnv = []string{
+	"LANG=en_US.UTF-8",
+	DefaultPath,
+}
+
 // Cmd represents a command to be run.
 type Cmd struct {
 	// Path is the path of the command to run.
@@ -22,8 +29,7 @@ type Cmd struct {
 
 	// Env specifies the environment of the process.
 	// Each entry is of the form "key=value".
-	// If Env is nil, the new process uses LANG=en_US.UTF-8 and PATH set to the
-	// default path.
+	// If Env is nil, the new process uses DefaultEnv.
 	// If Env contains duplicate environment keys, only the last
 	// value in the slice for each duplicate key is used.
 	Env []string

--- a/internal/host/agent_client_wrapper_linux_test.go
+++ b/internal/host/agent_client_wrapper_linux_test.go
@@ -18,5 +18,6 @@ func TestAgentClientWrapper(t *testing.T) {
 	defer func() { require.NoError(t, host.Close(ctx)) }()
 	require.NoError(t, err)
 
-	testHost(t, ctx, host, baseHost.String(), baseHost.Type())
+	tempDir := t.TempDir()
+	testHost(t, ctx, tempDir, host, baseHost.String(), baseHost.Type())
 }

--- a/internal/host/docker_unix_test.go
+++ b/internal/host/docker_unix_test.go
@@ -1,0 +1,102 @@
+package host
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fornellas/resonance/log"
+)
+
+func TestDocker(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker command not found on path")
+	}
+
+	ctx := context.Background()
+	ctx = log.WithTestLogger(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+
+	tempDir := t.TempDir()
+
+	name := fmt.Sprintf("resonance-%s-%d", t.Name(), os.Getpid())
+	cmd := exec.CommandContext(
+		ctx,
+		"docker", "run",
+		"--name", name,
+		"--rm",
+		"--volume", fmt.Sprintf("%s:%s", tempDir, tempDir),
+		"debian",
+		"sleep", "5",
+	)
+	stdout := bytes.Buffer{}
+	cmd.Stdout = &stdout
+	stderr := bytes.Buffer{}
+	cmd.Stderr = &stderr
+	cmd.Start()
+	defer func() {
+		cancel()
+		err := cmd.Wait()
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			if waitStatus, ok := exitError.Sys().(syscall.WaitStatus); ok {
+				if waitStatus.Signaled() && waitStatus.Signal() == syscall.SIGKILL {
+					return
+				}
+			}
+		}
+		assert.NoError(t, err, fmt.Sprintf(
+			"docker run returned error:\nstdout:\n%s\nstderr\n%s", stdout.String(), stderr.String()),
+		)
+	}()
+
+	timeoutCh := time.After(2 * time.Minute)
+	for {
+		select {
+		case <-timeoutCh:
+			t.Fatalf("timeout waiting for container")
+		case <-time.After(100 * time.Millisecond):
+		}
+		cmdCheck := exec.CommandContext(ctx, "docker", "exec", name, "/bin/true")
+		stdoutBuffer := bytes.Buffer{}
+		cmdCheck.Stdout = &stdoutBuffer
+		stderrBuffer := bytes.Buffer{}
+		cmdCheck.Stderr = &stderrBuffer
+		err := cmdCheck.Run()
+		if err != nil {
+			var exitError *exec.ExitError
+			if ok := errors.As(err, &exitError); ok {
+				if exitError.Exited() {
+					if strings.Contains(stderrBuffer.String(), "No such container") {
+						continue
+					}
+					if strings.Contains(stderrBuffer.String(), "is not running") {
+						continue
+					}
+				}
+			}
+			require.NoErrorf(
+				t, err,
+				"failed: %s %s:\nstdout:\n%s\n\nstderr\n%s", cmd.Path, cmd.Args, stdoutBuffer.String(), stderrBuffer.String(),
+			)
+		}
+		break
+	}
+
+	connection := fmt.Sprintf("0:0@%s", name)
+	baseHost, err := NewDocker(ctx, connection)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, baseHost.Close(ctx)) }()
+
+	testBaseHost(t, ctx, tempDir, baseHost, connection, "docker")
+}

--- a/internal/host/lib/run_unix.go
+++ b/internal/host/lib/run_unix.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 	"io/fs"
-	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/fornellas/resonance/host"
@@ -17,15 +15,10 @@ import (
 func Run(ctx context.Context, cmd host.Cmd) (host.WaitStatus, error) {
 	execCmd := exec.CommandContext(ctx, cmd.Path, cmd.Args...)
 	if len(cmd.Env) == 0 {
-		cmd.Env = []string{"LANG=en_US.UTF-8"}
-		for _, value := range os.Environ() {
-			if strings.HasPrefix(value, "PATH=") {
-				cmd.Env = append(cmd.Env, value)
-				break
-			}
-		}
+		execCmd.Env = host.DefaultEnv
+	} else {
+		execCmd.Env = cmd.Env
 	}
-	execCmd.Env = cmd.Env
 
 	if cmd.Dir == "" {
 		cmd.Dir = "/tmp"

--- a/internal/host/lib_unix_test.go
+++ b/internal/host/lib_unix_test.go
@@ -1,0 +1,154 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/fornellas/resonance/host"
+)
+
+func testBaseHost(
+	t *testing.T,
+	ctx context.Context,
+	tmpDir string,
+	baseHost host.BaseHost,
+	baseHostString,
+	baseHostType string,
+) {
+	t.Run("Run", func(t *testing.T) {
+		t.Run("Args, output and failure", func(t *testing.T) {
+			waitStatus, stdout, stderr, err := host.Run(ctx, baseHost, host.Cmd{
+				Path: "ls",
+				Args: []string{"-d", "../tmp", "/non-existent"},
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				if t.Failed() {
+					t.Logf("\nstdout:\n%s\nstderr:\n%s\n", stdout, stderr)
+				}
+			})
+			require.False(t, waitStatus.Success())
+			require.Equal(t, 2, waitStatus.ExitCode)
+			require.True(t, waitStatus.Exited)
+			require.Equal(t, "", waitStatus.Signal)
+			require.Equal(t, "../tmp\n", stdout)
+			require.Equal(t, "ls: cannot access '/non-existent': No such file or directory\n", stderr)
+		})
+		t.Run("Env", func(t *testing.T) {
+			t.Run("Empty", func(t *testing.T) {
+				waitStatus, stdout, stderr, err := host.Run(ctx, baseHost, host.Cmd{
+					Path: "env",
+				})
+				t.Cleanup(func() {
+					if t.Failed() {
+						t.Logf("stdout:\n%s\nstderr:\n%s\n", stdout, stderr)
+					}
+				})
+				require.NoError(t, err)
+
+				require.True(t, waitStatus.Success())
+				require.Equal(t, 0, waitStatus.ExitCode)
+				require.True(t, waitStatus.Exited)
+				require.Equal(t, "", waitStatus.Signal)
+
+				receivedEnv := []string{}
+				for _, value := range strings.Split(stdout, "\n") {
+					if value == "" {
+						continue
+					}
+					receivedEnv = append(receivedEnv, value)
+				}
+				sort.Strings(receivedEnv)
+				require.Equal(t, host.DefaultEnv, receivedEnv)
+				require.Empty(t, stderr)
+			})
+			t.Run("Set", func(t *testing.T) {
+				env := "FOO=bar"
+				waitStatus, stdout, stderr, err := host.Run(ctx, baseHost, host.Cmd{
+					Path: "env",
+					Env:  []string{env},
+				})
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					if t.Failed() {
+						t.Logf("stdout:\n%s\nstderr:\n%s\n", stdout, stderr)
+					}
+				})
+				require.True(t, waitStatus.Success())
+				require.Equal(t, 0, waitStatus.ExitCode)
+				require.True(t, waitStatus.Exited)
+				require.Equal(t, "", waitStatus.Signal)
+				require.Equal(t, env, strings.TrimRight(stdout, "\n"))
+				require.Empty(t, stderr)
+			})
+		})
+		t.Run("Dir", func(t *testing.T) {
+			t.Run("Success", func(t *testing.T) {
+				dir, err := os.MkdirTemp(tmpDir, strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_"))
+				require.NoError(t, err)
+				waitStatus, stdout, stderr, err := host.Run(ctx, baseHost, host.Cmd{
+					Path: "pwd",
+					Dir:  dir,
+				})
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					if t.Failed() {
+						t.Logf("\nstdout:\n%s\nstderr:\n%s\n", stdout, stderr)
+					}
+				})
+				require.True(t, waitStatus.Success())
+				require.Equal(t, 0, waitStatus.ExitCode)
+				require.True(t, waitStatus.Exited)
+				require.Equal(t, "", waitStatus.Signal)
+				require.Equal(t, fmt.Sprintf("%s\n", dir), stdout)
+				require.Equal(t, "", stderr)
+			})
+			t.Run("path must be absolute", func(t *testing.T) {
+				_, _, _, err := host.Run(ctx, baseHost, host.Cmd{
+					Path: "pwd",
+					Dir:  "foo/bar",
+				})
+				require.ErrorContains(t, err, "path must be absolute")
+			})
+		})
+		t.Run("Stdin", func(t *testing.T) {
+			stdin := "hello"
+			waitStatus, stdout, stderr, err := host.Run(ctx, baseHost, host.Cmd{
+				Path:  "sh",
+				Args:  []string{"-c", "read v && echo =$v="},
+				Stdin: strings.NewReader(fmt.Sprintf("%s\n", stdin)),
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				if t.Failed() {
+					t.Logf("\nstdout:\n%s\nstderr:\n%s\n", stdout, stderr)
+				}
+			})
+			require.True(t, waitStatus.Success())
+			require.Equal(t, 0, waitStatus.ExitCode)
+			require.True(t, waitStatus.Exited)
+			require.Equal(t, "", waitStatus.Signal)
+			require.Equal(t, fmt.Sprintf("=%s=\n", stdin), stdout)
+			require.Equal(t, "", stderr)
+		})
+	})
+
+	t.Run("String()", func(t *testing.T) {
+		require.Equal(t, baseHostString, baseHost.String())
+	})
+
+	t.Run("Type()", func(t *testing.T) {
+		require.Equal(t, baseHostType, baseHost.Type())
+	})
+
+	t.Run("Close()", func(t *testing.T) {
+		t.SkipNow()
+		require.NoError(t, baseHost.Close(ctx))
+	})
+}

--- a/internal/host/local_linux_test.go
+++ b/internal/host/local_linux_test.go
@@ -16,5 +16,6 @@ func TestLocal(t *testing.T) {
 	host := Local{}
 	defer func() { require.NoError(t, host.Close(ctx)) }()
 
-	testHost(t, ctx, host, "localhost", "localhost")
+	tempDir := t.TempDir()
+	testHost(t, ctx, tempDir, host, "localhost", "localhost")
 }

--- a/internal/host/ssh_linux_test.go
+++ b/internal/host/ssh_linux_test.go
@@ -98,5 +98,6 @@ func TestSsh(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, baseHost.Close(ctx)) }()
 
-	testBaseHost(t, ctx, baseHost, "localhost", "ssh")
+	tempDir := t.TempDir()
+	testBaseHost(t, ctx, tempDir, baseHost, "localhost", "ssh")
 }

--- a/internal/host/sudo_wrapper_linux_test.go
+++ b/internal/host/sudo_wrapper_linux_test.go
@@ -70,5 +70,6 @@ func TestSudo(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, baseHost.Close(ctx)) }()
 
-	testBaseHost(t, ctx, baseHost, wrappedBaseHost.String(), wrappedBaseHost.Type())
+	tempDir := t.TempDir()
+	testBaseHost(t, ctx, tempDir, baseHost, wrappedBaseHost.String(), wrappedBaseHost.Type())
 }


### PR DESCRIPTION
We were missing tests for Docker, let's add them.

This caught a bug, where the client's environment was being wrongly copied to the target. To fix this, we're now defining a `DefaultEnv`, and having the tests assert for it. This ensures predictability when running commands, as opposed to the client's environment leaking to the target.

---

**Stack**:
- #159
- #209
- #208
- #215 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*