### PR TITLE
Stream Host.ReadDir results

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -57,7 +57,7 @@ type Host interface {
 	Lstat(ctx context.Context, name string) (*Stat_t, error)
 
 	// ReadDir reads the named directory, returning all its DirEnt.
-	ReadDir(ctx context.Context, name string) ([]DirEnt, error)
+	ReadDir(ctx context.Context, name string) (dirEntResultCh <-chan DirEntResult, cancel func())
 
 	// Mkdir works similar to syscall.Mkdir, but ignoring umask.
 	Mkdir(ctx context.Context, name string, mode uint32) error

--- a/host/types.go
+++ b/host/types.go
@@ -140,3 +140,8 @@ func (d *DirEnt) IsRegularFile() bool {
 func (d *DirEnt) IsUnixDomainSocket() bool {
 	return d.Type == syscall.DT_SOCK
 }
+
+type DirEntResult struct {
+	DirEnt DirEnt
+	Error  error
+}

--- a/internal/host/agent_server/proto/service.proto
+++ b/internal/host/agent_server/proto/service.proto
@@ -13,7 +13,7 @@ service HostService {
   rpc Lookup(LookupRequest) returns (LookupResponse) {}
   rpc LookupGroup(LookupGroupRequest) returns (LookupGroupResponse) {}
   rpc Lstat(LstatRequest) returns (LstatResponse) {}
-  rpc ReadDir(ReadDirRequest) returns (ReadDirResponse) {}
+  rpc ReadDir(ReadDirRequest) returns (stream DirEnt) {}
   rpc Mkdir(MkdirRequest) returns (Empty) {}
   rpc ReadFile(ReadFileRequest) returns (stream ReadFileResponse) {}
   rpc Symlink(SymlinkRequest) returns (Empty) {}
@@ -113,10 +113,6 @@ message DirEnt {
   uint64 ino = 1;
   int32 type = 2;
   string name = 3;
-}
-
-message ReadDirResponse {
-  repeated DirEnt entries = 1;
 }
 
 message Empty {

--- a/internal/host/lib/readdir_linux.go
+++ b/internal/host/lib/readdir_linux.go
@@ -12,63 +12,84 @@ import (
 )
 
 // Implements Host.Run for Linux locahost.
-func ReadDir(ctx context.Context, name string) ([]host.DirEnt, error) {
-	if !filepath.IsAbs(name) {
-		return nil, &fs.PathError{
-			Op:   "ReadDir",
-			Path: name,
-			Err:  errors.New("path must be absolute"),
+func ReadDir(ctx context.Context, name string) (<-chan host.DirEntResult, func()) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	dirEntResultCh := make(chan host.DirEntResult, 100)
+
+	go func() {
+		if !filepath.IsAbs(name) {
+			dirEntResultCh <- host.DirEntResult{
+				Error: &fs.PathError{
+					Op:   "ReadDir",
+					Path: name,
+					Err:  errors.New("path must be absolute"),
+				},
+			}
+			close(dirEntResultCh)
+			return
 		}
-	}
 
-	fd, err := syscall.Open(name, syscall.O_RDONLY, 0)
-	if err != nil {
-		return nil, err
-	}
-	defer syscall.Close(fd)
-
-	buf := make([]byte, 4096)
-
-	dirEnts := []host.DirEnt{}
-	for {
-		// We do this via syscall.Getdents instead of os.ReadDir, because the latter
-		// requires doing aditional stat calls, which is slower.
-		n, err := syscall.Getdents(fd, buf)
+		fd, err := syscall.Open(name, syscall.O_RDONLY, 0)
 		if err != nil {
-			return nil, err
+			dirEntResultCh <- host.DirEntResult{Error: err}
+			close(dirEntResultCh)
+			return
 		}
+		defer syscall.Close(fd)
 
-		if n == 0 {
-			break
-		}
+		buf := make([]byte, 8196)
 
-		offset := 0
-		for offset < n {
-			dirent := (*syscall.Dirent)(unsafe.Pointer(&buf[offset]))
+		for {
+			// We do this via syscall.Getdents instead of os.ReadDir, because the latter
+			// requires doing aditional stat calls, which is slower.
+			n, err := syscall.Getdents(fd, buf)
+			if err != nil {
+				dirEntResultCh <- host.DirEntResult{Error: err}
+				break
+			}
 
-			var l int
-			for l = 0; l < len(dirent.Name); l++ {
-				if dirent.Name[l] == 0 {
-					break
+			if n == 0 {
+				break
+			}
+
+			offset := 0
+			for offset < n {
+				dirent := (*syscall.Dirent)(unsafe.Pointer(&buf[offset]))
+
+				var l int
+				for l = 0; l < len(dirent.Name); l++ {
+					if dirent.Name[l] == 0 {
+						break
+					}
 				}
-			}
-			nameBytes := make([]byte, l)
-			for i := 0; i < l; i++ {
-				nameBytes[i] = byte(dirent.Name[i])
-			}
-			name := string(nameBytes)
+				nameBytes := make([]byte, l)
+				for i := 0; i < l; i++ {
+					nameBytes[i] = byte(dirent.Name[i])
+				}
+				name := string(nameBytes)
 
-			if name != "." && name != ".." {
-				dirEnts = append(dirEnts, host.DirEnt{
-					Ino:  dirent.Ino,
-					Type: dirent.Type,
-					Name: name,
-				})
-			}
+				if name != "." && name != ".." {
+					dirEnt := host.DirEnt{
+						Ino:  dirent.Ino,
+						Type: dirent.Type,
+						Name: name,
+					}
 
-			offset += int(dirent.Reclen)
+					select {
+					case dirEntResultCh <- host.DirEntResult{DirEnt: dirEnt}:
+					case <-ctx.Done():
+						close(dirEntResultCh)
+						return
+					}
+				}
+
+				offset += int(dirent.Reclen)
+			}
 		}
-	}
 
-	return dirEnts, nil
+		close(dirEntResultCh)
+	}()
+
+	return dirEntResultCh, cancel
 }

--- a/internal/host/local_linux.go
+++ b/internal/host/local_linux.go
@@ -120,7 +120,7 @@ func (h Local) Lstat(ctx context.Context, name string) (*host.Stat_t, error) {
 	}, nil
 }
 
-func (h Local) ReadDir(ctx context.Context, name string) ([]host.DirEnt, error) {
+func (h Local) ReadDir(ctx context.Context, name string) (<-chan host.DirEntResult, func()) {
 	logger := log.MustLogger(ctx)
 	logger.Debug("ReadDir", "name", name)
 


### PR DESCRIPTION
Instead of piling up all `DirEnt` in memory, we use channels to stream them to callers.

---

**Stack**:
- #159
- #209
- #208
- #215
- #216 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*