### PR TITLE
Auto-update protoc, misc Makefile & CI improvements

### DIFF
--- a/.github/workflows/build-darwin.yaml
+++ b/.github/workflows/build-darwin.yaml
@@ -27,11 +27,6 @@ jobs:
       # Checkout
       - name: Checkout
         uses: actions/checkout@v4
-      # Setup Go
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
       # Make
       - name: Setup Make
         run: brew install make


### PR DESCRIPTION
Closes #123.

Extras:

- use consistent name for help targets.
- rename `go` to `install-go` for consistency
- add `install-tools` target, and call it for shell: this ensures the shell always has the correct go version, to prevent issues when go version is updated.
- rename `bulid.sh` to `make.sh`, as it is essentially a make wrapper.
- join all install targets together for easier maintenance.
- fixed broken `protoc-*` clean targets
- added CI check against left over files on cache after clean
- join all generate targets for easier maintenance.
- audo-update protoc with `update-deps` call
- fixed new go version not being installed after it was updated
- fix darwin build wrongly doing go setup (the Makefile manages versions).

---

**Stack**:
- #159
- #209
- #208
- #215
- #216
- #202
- #211
- #214
- #212
- #204
- #213
- #210
- #207
- #206
- #199
- #203
- #200
- #197
- #196
- #217 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*