### PR TITLE
Decrease final binary sizes by ~43%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ PROTOLINT_ARGS :=
 
 # go build
 
-GO_BUILD_FLAGS :=
+GO_BUILD_FLAGS := -trimpath -ldflags "-s -w"
 
 # osusergo have Lookup and LookupGroup to use pure Go implementation to enable
 # management of local users
@@ -229,7 +229,7 @@ else
 GO_BUILD_AGENT_GOARCHS := $(GOARCH)
 endif
 
-GO_BUILD_MAX_AGENT_SIZE := 8000000
+GO_BUILD_MAX_AGENT_SIZE := 4000000
 
 # rrb
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ The default build with `ci` reproduces the official build, but this may be too s
 ./make.sh ci-dev # or "make ci-dev"
 ```
 
+### Enable debugging symbols
+
+By default, both the embedded agents and final binaries are built without debugging symbols by use of extra `go build` flags.
+
+During development, it can be useful to have debugging symbols enabled. This can be accomplished by:
+
+```shell
+make ci GO_BUILD_FLAGS='' GO_BUILD_MAX_AGENT_SIZE=10000000
+```
+
+PS: tests _do_ run with debugging symbols.
+
 ### Automatic builds on Linux
 
 The build system is integrated with [rrb](https://github.com/fornellas/rrb), which enables the build to run automatically as you edit the files.


### PR DESCRIPTION
This PR adds some extra go build flags that substantially decrease the final binary sizes:

```
# Before
$ ls -lh resonance.linux.amd64 internal/host/agent_server/agent_server_linux_*.gz
-rw-rw-r-- 1 fornellas fornellas 7.0M Feb  9 00:34 internal/host/agent_server/agent_server_linux_386.gz
-rw-rw-r-- 1 fornellas fornellas 7.4M Feb  9 00:34 internal/host/agent_server/agent_server_linux_amd64.gz
-rw-rw-r-- 1 fornellas fornellas 6.9M Feb  9 00:34 internal/host/agent_server/agent_server_linux_arm64.gz
-rw-rw-r-- 1 fornellas fornellas 6.7M Feb  9 00:34 internal/host/agent_server/agent_server_linux_arm.gz
-rwxrwxr-x 1 fornellas fornellas  46M Feb  9 00:34 resonance.linux.amd64
# After
$ ls -lh resonance.linux.amd64 internal/host/agent_server/agent_server_linux_*.gz
-rw-rw-r-- 1 fornellas fornellas 3.5M Feb  9 00:34 internal/host/agent_server/agent_server_linux_386.gz
-rw-rw-r-- 1 fornellas fornellas 3.7M Feb  9 00:34 internal/host/agent_server/agent_server_linux_amd64.gz
-rw-rw-r-- 1 fornellas fornellas 3.4M Feb  9 00:34 internal/host/agent_server/agent_server_linux_arm64.gz
-rw-rw-r-- 1 fornellas fornellas 3.4M Feb  9 00:34 internal/host/agent_server/agent_server_linux_arm.gz
-rwxrwxr-x 1 fornellas fornellas  26M Feb  9 00:34 resonance.linux.amd64
```

These flags are used both for building the agents, which are embedded in the final binary, and the final binary.

Closes #81.