### PR TITLE
Change Chown to Lchown

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -39,8 +39,8 @@ type Host interface {
 	// Chmod works similar to syscall.Chmod.
 	Chmod(ctx context.Context, name string, mode uint32) error
 
-	// Chown works similar to syscall.Chown.
-	Chown(ctx context.Context, name string, uid, gid uint32) error
+	// Lchown works similar to syscall.Lchown.
+	Lchown(ctx context.Context, name string, uid, gid uint32) error
 
 	// Hostname works similar to os.Hostname.
 	// Hostname() (ctx context.Context, name string, err error)

--- a/internal/blueprint/step.go
+++ b/internal/blueprint/step.go
@@ -131,7 +131,7 @@ func (s *Step) Resolve(ctx context.Context, hst host.Host) error {
 			return err
 		}
 		if err := resourcesPkg.ValidateResource(s.singleResource); err != nil {
-			panic(fmt.Sprintf("bug: Resource Validate() failed after Resoslve(): %s", err.Error()))
+			panic(fmt.Sprintf("bug: Resource Validate() failed after Resolve(): %s", err.Error()))
 		}
 		return nil
 	}
@@ -142,7 +142,7 @@ func (s *Step) Resolve(ctx context.Context, hst host.Host) error {
 			return err
 		}
 		if err := s.groupResources.Validate(); err != nil {
-			panic(fmt.Sprintf("bug: Resource Validate() failed after Resoslve(): %s", err.Error()))
+			panic(fmt.Sprintf("bug: Resource Validate() failed after Resolve(): %s", err.Error()))
 		}
 		return nil
 	}

--- a/internal/host/agent_client_wrapper.go
+++ b/internal/host/agent_client_wrapper.go
@@ -384,11 +384,11 @@ func (h *AgentClientWrapper) Chmod(ctx context.Context, name string, mode uint32
 	return nil
 }
 
-func (h *AgentClientWrapper) Chown(ctx context.Context, name string, uid, gid uint32) error {
+func (h *AgentClientWrapper) Lchown(ctx context.Context, name string, uid, gid uint32) error {
 	logger := log.MustLogger(ctx)
-	logger.Debug("Chown", "name", name, "uid", uid, "gid", gid)
+	logger.Debug("Lchown", "name", name, "uid", uid, "gid", gid)
 
-	_, err := h.hostServiceClient.Chown(ctx, &proto.ChownRequest{
+	_, err := h.hostServiceClient.Lchown(ctx, &proto.LchownRequest{
 		Name: name,
 		Uid:  int64(uid),
 		Gid:  int64(gid),

--- a/internal/host/agent_server/main_linux.go
+++ b/internal/host/agent_server/main_linux.go
@@ -75,24 +75,24 @@ func (s *HostService) Chmod(ctx context.Context, req *proto.ChmodRequest) (*prot
 	return &proto.ChmodResponse{Status: "chmod successful"}, nil
 }
 
-func (s *HostService) Chown(ctx context.Context, req *proto.ChownRequest) (*proto.ChownResponse, error) {
+func (s *HostService) Lchown(ctx context.Context, req *proto.LchownRequest) (*proto.LchownResponse, error) {
 	name := req.Name
 	uid := int(req.Uid)
 	gid := int(req.Gid)
 
 	if !filepath.IsAbs(name) {
 		return nil, &fs.PathError{
-			Op:   "Chown",
+			Op:   "Lchown",
 			Path: name,
 			Err:  errors.New("path must be absolute"),
 		}
 	}
 
-	if err := syscall.Chown(name, uid, gid); err != nil {
+	if err := syscall.Lchown(name, uid, gid); err != nil {
 		return nil, err
 	}
 
-	return &proto.ChownResponse{Status: "chown successful"}, nil
+	return &proto.LchownResponse{Status: "lchown successful"}, nil
 }
 
 func (s *HostService) Lookup(ctx context.Context, req *proto.LookupRequest) (*proto.LookupResponse, error) {

--- a/internal/host/agent_server/proto/service.proto
+++ b/internal/host/agent_server/proto/service.proto
@@ -9,7 +9,7 @@ service HostService {
   rpc Geteuid(Empty) returns (GeteuidResponse) {}
   rpc Getegid(Empty) returns (GetegidResponse) {}
   rpc Chmod(ChmodRequest) returns (ChmodResponse) {}
-  rpc Chown(ChownRequest) returns (ChownResponse) {}
+  rpc Lchown(LchownRequest) returns (LchownResponse) {}
   rpc Lookup(LookupRequest) returns (LookupResponse) {}
   rpc LookupGroup(LookupGroupRequest) returns (LookupGroupResponse) {}
   rpc Lstat(LstatRequest) returns (LstatResponse) {}
@@ -49,13 +49,13 @@ message ChmodResponse {
   string status = 1;
 }
 
-message ChownRequest {
+message LchownRequest {
   string name = 1;
   int64  uid = 2;
   int64  gid = 3;
 }
 
-message ChownResponse {
+message LchownResponse {
   string status = 1;
 }
 

--- a/internal/host/local_linux.go
+++ b/internal/host/local_linux.go
@@ -49,9 +49,9 @@ func (h Local) Chmod(ctx context.Context, name string, mode uint32) error {
 	return syscall.Chmod(name, mode)
 }
 
-func (h Local) Chown(ctx context.Context, name string, uid, gid uint32) error {
+func (h Local) Lchown(ctx context.Context, name string, uid, gid uint32) error {
 	logger := log.MustLogger(ctx)
-	logger.Debug("Chown", "name", name, "uid", uid, "gid", gid)
+	logger.Debug("Lchown", "name", name, "uid", uid, "gid", gid)
 
 	if !filepath.IsAbs(name) {
 		return &fs.PathError{
@@ -61,7 +61,7 @@ func (h Local) Chown(ctx context.Context, name string, uid, gid uint32) error {
 		}
 	}
 
-	return syscall.Chown(name, int(uid), int(gid))
+	return syscall.Lchown(name, int(uid), int(gid))
 }
 
 func (h Local) Lookup(ctx context.Context, username string) (*user.User, error) {

--- a/resources/file.go
+++ b/resources/file.go
@@ -156,7 +156,7 @@ func (f *File) Apply(ctx context.Context, hst host.Host) error {
 
 	// Uid / Gid
 	if fileInfo.Uid != f.Uid || fileInfo.Gid != f.Gid {
-		if err := hst.Chown(ctx, string(f.Path), f.Uid, f.Gid); err != nil {
+		if err := hst.Lchown(ctx, string(f.Path), f.Uid, f.Gid); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
In order to manage permissions from symlinks, we need `Lchown` as opposed to `Chown`.

---

**Stack**:
- #159
- #209
- #208
- #221 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*