### PR TITLE
Add fs.PathError to all path related Host functions

### DIFF
--- a/host/lib/host_linux.go
+++ b/host/lib/host_linux.go
@@ -79,7 +79,13 @@ func LocalReadDir(ctx context.Context, name string) (<-chan types.DirEntResult, 
 
 		fd, err := syscall.Open(name, syscall.O_RDONLY, 0)
 		if err != nil {
-			dirEntResultCh <- types.DirEntResult{Error: err}
+			dirEntResultCh <- types.DirEntResult{
+				Error: &fs.PathError{
+					Op:   "ReadDir",
+					Path: name,
+					Err:  err,
+				},
+			}
 			close(dirEntResultCh)
 			return
 		}
@@ -92,7 +98,13 @@ func LocalReadDir(ctx context.Context, name string) (<-chan types.DirEntResult, 
 			// requires doing aditional stat calls, which is slower.
 			n, err := syscall.Getdents(fd, buf)
 			if err != nil {
-				dirEntResultCh <- types.DirEntResult{Error: err}
+				dirEntResultCh <- types.DirEntResult{
+					Error: &fs.PathError{
+						Op:   "ReadDir",
+						Path: name,
+						Err:  err,
+					},
+				}
 				break
 			}
 

--- a/host/local_linux.go
+++ b/host/local_linux.go
@@ -34,19 +34,30 @@ func (h Local) Getegid(ctx context.Context) (uint64, error) {
 	return uint64(syscall.Getegid()), nil
 }
 
+func (h Local) getPathError(op, path string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) {
+		return &fs.PathError{
+			Op:   op,
+			Path: path,
+			Err:  err,
+		}
+	}
+	return err
+}
+
 func (h Local) Chmod(ctx context.Context, name string, mode types.FileMode) error {
 	logger := log.MustLogger(ctx)
 	logger.Debug("Chmod", "name", name, "mode", mode)
 
 	if !filepath.IsAbs(name) {
-		return &fs.PathError{
-			Op:   "Chmod",
-			Path: name,
-			Err:  errors.New("path must be absolute"),
-		}
+		return h.getPathError("Chmod", name, errors.New("path must be absolute"))
 	}
 
-	return syscall.Chmod(name, uint32(mode))
+	return h.getPathError("Chmod", name, syscall.Chmod(name, uint32(mode)))
 }
 
 func (h Local) Lchown(ctx context.Context, name string, uid, gid uint32) error {
@@ -54,14 +65,10 @@ func (h Local) Lchown(ctx context.Context, name string, uid, gid uint32) error {
 	logger.Debug("Lchown", "name", name, "uid", uid, "gid", gid)
 
 	if !filepath.IsAbs(name) {
-		return &fs.PathError{
-			Op:   "Chown",
-			Path: name,
-			Err:  errors.New("path must be absolute"),
-		}
+		return h.getPathError("Lchown", name, errors.New("path must be absolute"))
 	}
 
-	return syscall.Lchown(name, int(uid), int(gid))
+	return h.getPathError("Lchown", name, syscall.Lchown(name, int(uid), int(gid)))
 }
 
 func (h Local) Lookup(ctx context.Context, username string) (*user.User, error) {
@@ -81,17 +88,13 @@ func (h Local) Lstat(ctx context.Context, name string) (*types.Stat_t, error) {
 	logger.Debug("Lstat", "name", name)
 
 	if !filepath.IsAbs(name) {
-		return nil, &fs.PathError{
-			Op:   "Lstat",
-			Path: name,
-			Err:  errors.New("path must be absolute"),
-		}
+		return nil, h.getPathError("Lstat", name, errors.New("path must be absolute"))
 	}
 
 	var syscallStat_t syscall.Stat_t
 	err := syscall.Lstat(name, &syscallStat_t)
 	if err != nil {
-		return nil, err
+		return nil, h.getPathError("Lstat", name, err)
 	}
 
 	return &types.Stat_t{
@@ -132,17 +135,13 @@ func (h Local) Mkdir(ctx context.Context, name string, mode types.FileMode) erro
 	logger.Debug("Mkdir", "name", name, "mode", mode)
 
 	if !filepath.IsAbs(name) {
-		return &fs.PathError{
-			Op:   "Mkdir",
-			Path: name,
-			Err:  errors.New("path must be absolute"),
-		}
+		return h.getPathError("Mkdir", name, errors.New("path must be absolute"))
 	}
 
 	if err := syscall.Mkdir(name, uint32(mode)); err != nil {
-		return err
+		return h.getPathError("Mkdir", name, err)
 	}
-	return syscall.Chmod(name, uint32(mode))
+	return h.getPathError("Mkdir", name, syscall.Chmod(name, uint32(mode)))
 }
 
 func (h Local) ReadFile(ctx context.Context, name string) (io.ReadCloser, error) {
@@ -150,30 +149,25 @@ func (h Local) ReadFile(ctx context.Context, name string) (io.ReadCloser, error)
 	logger.Debug("ReadFile", "name", name)
 
 	if !filepath.IsAbs(name) {
-		return nil, &fs.PathError{
-			Op:   "ReadFile",
-			Path: name,
-			Err:  errors.New("path must be absolute"),
-		}
+		return nil, h.getPathError("ReadFile", name, errors.New("path must be absolute"))
 	}
 
 	f, err := os.Open(name)
 	if err != nil {
-		return nil, err
+		return nil, h.getPathError("ReadFile", name, err)
 	}
 	return f, nil
 }
 
 func (h Local) Symlink(ctx context.Context, oldname, newname string) error {
+	logger := log.MustLogger(ctx)
+	logger.Debug("Symlink", "oldname", oldname, "newname", newname)
+
 	if !path.IsAbs(newname) {
-		return &fs.PathError{
-			Op:   "Symlink",
-			Path: newname,
-			Err:  errors.New("path must be absolute"),
-		}
+		return h.getPathError("Symlink", newname, errors.New("path must be absolute"))
 	}
 
-	return syscall.Symlink(oldname, newname)
+	return h.getPathError("Symlink", newname, syscall.Symlink(oldname, newname))
 }
 
 func (h Local) Readlink(ctx context.Context, name string) (string, error) {
@@ -181,14 +175,14 @@ func (h Local) Readlink(ctx context.Context, name string) (string, error) {
 	logger.Debug("Readlink", "name", name)
 
 	if !filepath.IsAbs(name) {
-		return "", &fs.PathError{
-			Op:   "Readlink",
-			Path: name,
-			Err:  errors.New("path must be absolute"),
-		}
+		return "", h.getPathError("Readlink", name, errors.New("path must be absolute"))
 	}
 
-	return os.Readlink(name)
+	oldname, err := os.Readlink(name)
+	if err != nil {
+		return "", h.getPathError("Readlink", name, err)
+	}
+	return oldname, nil
 }
 
 func (h Local) Remove(ctx context.Context, name string) error {
@@ -196,14 +190,10 @@ func (h Local) Remove(ctx context.Context, name string) error {
 	logger.Debug("Remove", "name", name)
 
 	if !filepath.IsAbs(name) {
-		return &fs.PathError{
-			Op:   "Remove",
-			Path: name,
-			Err:  errors.New("path must be absolute"),
-		}
+		return h.getPathError("Remove", name, errors.New("path must be absolute"))
 	}
 
-	return os.Remove(name)
+	return h.getPathError("Remove", name, os.Remove(name))
 }
 
 func (h Local) Mknod(ctx context.Context, pathName string, mode types.FileMode, dev types.FileDevice) error {
@@ -211,18 +201,18 @@ func (h Local) Mknod(ctx context.Context, pathName string, mode types.FileMode, 
 	logger.Debug("Mknod", "pathName", pathName, "mode", mode, "dev", dev)
 
 	if !path.IsAbs(pathName) {
-		return fmt.Errorf("path must be absolute: %#v", pathName)
+		return h.getPathError("Mknod", pathName, fmt.Errorf("path must be absolute"))
 	}
 
 	if dev != types.FileDevice(int(dev)) {
-		return fmt.Errorf("dev value is too big: %#v", dev)
+		return h.getPathError("Mknod", pathName, fmt.Errorf("dev value is too big: %#v", dev))
 	}
 
 	if err := syscall.Mknod(pathName, uint32(mode), int(dev)); err != nil {
-		return err
+		return h.getPathError("Mknod", pathName, err)
 	}
 
-	return syscall.Chmod(pathName, uint32(mode)&07777)
+	return h.getPathError("Mknod", pathName, syscall.Chmod(pathName, uint32(mode)&07777))
 }
 
 func (h Local) Run(ctx context.Context, cmd types.Cmd) (types.WaitStatus, error) {
@@ -236,24 +226,20 @@ func (h Local) WriteFile(ctx context.Context, name string, data io.Reader, mode 
 	logger.Debug("WriteFile", "name", name, "data", data, "mode", mode)
 
 	if !filepath.IsAbs(name) {
-		return &fs.PathError{
-			Op:   "WriteFile",
-			Path: name,
-			Err:  errors.New("path must be absolute"),
-		}
+		return h.getPathError("WriteFile", name, errors.New("path must be absolute"))
 	}
 
 	file, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(mode))
 	if err != nil {
-		return err
+		return h.getPathError("WriteFile", name, err)
 	}
 
 	_, err = io.Copy(file, data)
 	if err != nil {
-		return errors.Join(err, file.Close())
+		return h.getPathError("WriteFile", name, errors.Join(err, file.Close()))
 	}
 
-	return errors.Join(syscall.Chmod(name, uint32(mode)), file.Close())
+	return h.getPathError("WriteFile", name, errors.Join(syscall.Chmod(name, uint32(mode)), file.Close()))
 }
 
 func (h Local) String() string {


### PR DESCRIPTION
This makes debugging possible, otherwise we just get a generic error such as "permission denied", and no idea where...

---

**Stack**:
- #209
- #241
- #244 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*