### PR TITLE
Add missing SSH options

### DIFF
--- a/cmd/lib.go
+++ b/cmd/lib.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -26,18 +27,63 @@ var storeValue = NewStoreValue()
 var storeHostTargetPath string
 var defaultStoreHostTargetPath = "/var/lib/resonance"
 
+var sshRekeyThreshold uint64
+var defaultSshRekeyThreshold uint64 = 0
+
+var sshKeyExchanges []string
+var defaultSshKeyExchanges = []string{}
+
+var sshCiphers []string
+var defaultSshCiphers = []string{}
+
+var sshMACs []string
+var defaultSshMACs = []string{}
+
+var sshHostKeyAlgorithms []string
+var defaultSshHostKeyAlgorithms = []string{}
+
+var sshTcpConnectTimeout time.Duration
+var defaultSshTcpConnectTimeout = time.Second * 30
+
 func addHostFlagsCommon(cmd *cobra.Command) {
+	// Ssh
 	cmd.Flags().StringVarP(
 		&ssh, "target-ssh", "s", defaultSsh,
 		"Applies configuration to given hostname using SSH in the format: [<user>[;fingerprint=<host-key fingerprint>]@]<host>[:<port>]",
 	)
+	cmd.Flags().Uint64Var(
+		&sshRekeyThreshold, "target-ssh-rekey-threshold", defaultSshRekeyThreshold,
+		"The maximum number of bytes sent or received after which a new key is negotiated. It must be at least 256. If unspecified, a size suitable for the chosen cipher is used.",
+	)
+	cmd.Flags().StringSliceVar(
+		&sshKeyExchanges, "target-ssh-key-exchanges", defaultSshKeyExchanges,
+		"The allowed key exchanges algorithms. If unspecified then a default set of algorithms is used. Unsupported values are silently ignored.",
+	)
+	cmd.Flags().StringSliceVar(
+		&sshCiphers, "target-ssh-ciphers", defaultSshCiphers,
+		"The allowed cipher algorithms. If unspecified then a sensible default is used. Unsupported values are silently ignored.",
+	)
+	cmd.Flags().StringSliceVar(
+		&sshMACs, "target-ssh-macs", defaultSshMACs,
+		"The allowed MAC algorithms. If unspecified then a sensible default is used. Unsupported values are silently ignored.",
+	)
+	cmd.Flags().StringSliceVar(
+		&sshHostKeyAlgorithms, "target-ssh-host-key-algorithms", defaultSshHostKeyAlgorithms,
+		"Public key algorithms that the client will accept from the server for host key authentication, in order of preference. If empty, a reasonable default is used.",
+	)
+	cmd.Flags().DurationVar(
+		&sshTcpConnectTimeout, "target-ssh-tcp-connect-timeout", defaultSshTcpConnectTimeout,
+		"Timeout is the maximum amount of time for the TCP connection to establish. A Timeout of zero means no timeout.",
+	)
 
+	// Docker
 	cmd.Flags().StringVarP(
 		&docker, "target-docker", "d", defaultDocker,
 		"Applies configuration to given Docker container name \n"+
 			"Use given format '[<name|uid>[:<group|gid>]@]<image>'",
 	)
 
+	// Common
 	cmd.Flags().BoolVarP(
 		&sudo, "target-sudo", "r", defaultSudo,
 		"Use sudo to gain root privileges",

--- a/cmd/lib_darwin.go
+++ b/cmd/lib_darwin.go
@@ -17,7 +17,14 @@ func GetHost(ctx context.Context) (types.Host, error) {
 	var err error
 
 	if ssh != "" {
-		baseHost, err = hostPkg.NewSshAuthority(ctx, ssh)
+		baseHost, err = hostPkg.NewSshAuthority(ctx, ssh, hostPkg.SshClientConfig{
+			RekeyThreshold:    sshRekeyThreshold,
+			KeyExchanges:      sshKeyExchanges,
+			Ciphers:           sshCiphers,
+			MACs:              sshMACs,
+			HostKeyAlgorithms: sshHostKeyAlgorithms,
+			Timeout:           sshTcpConnectTimeout,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/lib_linux.go
+++ b/cmd/lib_linux.go
@@ -28,7 +28,14 @@ func GetHost(ctx context.Context) (types.Host, error) {
 			return hostPkg.Local{}, nil
 		}
 	} else if ssh != "" {
-		baseHost, err = hostPkg.NewSshAuthority(ctx, ssh)
+		baseHost, err = hostPkg.NewSshAuthority(ctx, ssh, hostPkg.SshClientConfig{
+			RekeyThreshold:    sshRekeyThreshold,
+			KeyExchanges:      sshKeyExchanges,
+			Ciphers:           sshCiphers,
+			MACs:              sshMACs,
+			HostKeyAlgorithms: sshHostKeyAlgorithms,
+			Timeout:           sshTcpConnectTimeout,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/host/ssh_linux_test.go
+++ b/host/ssh_linux_test.go
@@ -91,10 +91,8 @@ func TestSsh(t *testing.T) {
 	go server.Serve(listener)
 	defer func() { server.Close() }()
 
-	baseHost, err := NewSshAuthority(ctx, fmt.Sprintf(
-		"%s;fingerprint=%s@localhost:%d",
-		username, serverFingerprint, port,
-	))
+	authority := fmt.Sprintf("%s;fingerprint=%s@localhost:%d", username, serverFingerprint, port)
+	baseHost, err := NewSshAuthority(ctx, authority, SshClientConfig{})
 	require.NoError(t, err)
 	defer func() { require.NoError(t, baseHost.Close(ctx)) }()
 


### PR DESCRIPTION
Ssh client has various extra options which were not exposed. Without them, connecting to hosts may be impossible. Eg:

- `ssh` command has its own list of `HostKeyAlgorithms`.
- `ssh` successfully connects to a host, using one of the algorithms there, and adds the fingerprint to `known_hosts`.
- Go has _its own_ values for that at https://pkg.go.dev/golang.org/x/crypto/ssh#ClientConfig.
- Go may then find a _different_ host key algorithm to connect, and attempts to connect.
- `known_hosts` validation fails with https://pkg.go.dev/golang.org/x/crypto@v0.33.0/ssh/knownhosts#KeyError, because the chosen host key algorithm differs from the key algorithm present on `known_hosts` (added by `ssh` previously).
- The error message is cryptic: `"knownhosts: key mismatch"`.

This PR:

- Wraps around `KeyError`, with information regarding the host key algorithm and any entries at `known_hosts`. It also suggests ways around it.
- Add all extra ssh client options that we may ever need, so wahtever the scenario, we'll be able to connect.

In the failure scenario above, connection can be established by either:

- Passing `--target-ssh-host-key-algorithms=$(known_hosts key algorithm)`.
- `ssh-keygen -R $host` then `ssh -o HostKeyAlgorithms=$(preferred algorithm used by Go and `ssh``) $host` (eg: `ecdsa-sha2-nistp256`).

The former is easy, the latter a bit hard. We can see the algos from ssh with `ssh -Q HostKeyAlgorithms`, but Go, sadly, makes this list private. As of now, this is the list:

```
"rsa-sha2-256-cert-v01@openssh.com"
"rsa-sha2-512-cert-v01@openssh.com"
"ssh-rsa-cert-v01@openssh.com"
"ssh-dss-cert-v01@openssh.com"
"ecdsa-sha2-nistp256-cert-v01@openssh.com"
"ecdsa-sha2-nistp384-cert-v01@openssh.com"
"ecdsa-sha2-nistp521-cert-v01@openssh.com"
"ssh-ed25519-cert-v01@openssh.com"
"ecdsa-sha2-nistp256"
"ecdsa-sha2-nistp384"
"ecdsa-sha2-nistp521"
"rsa-sha2-256"
"rsa-sha2-512"
"ssh-rsa"
"ssh-dss"
"ssh-ed25519"
```

so ssh would need to connect using the top most common algorithm between both, so that connections can "just work" by either ssh and go after.

---

**Stack**:
- #209
- #241
- #245 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*