### PR TITLE
Fix agent stop race condition

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -29,6 +29,7 @@ var PlanCmd = &cobra.Command{
 		defer func() {
 			if err := host.Close(ctx); err != nil {
 				logger.Error("failed to close host", "error", err)
+				Exit(1)
 			}
 		}()
 		ctx, _ = log.MustWithAttrs(ctx, "host", fmt.Sprintf("%s => %s", host.Type(), host.String()))

--- a/host/agent_server/proto/service.proto
+++ b/host/agent_server/proto/service.proto
@@ -23,7 +23,6 @@ service HostService {
   rpc Mknod(MknodRequest) returns (Empty) {}
   rpc WriteFile(stream WriteFileRequest) returns (Empty) {}
   rpc AppendFile(stream AppendFileRequest) returns (Empty) {}
-  rpc Shutdown(Empty) returns (Empty) {}
 }
 
 message Errno {

--- a/host/net/net.go
+++ b/host/net/net.go
@@ -30,13 +30,11 @@ type IOConn struct {
 }
 
 func (c IOConn) Read(b []byte) (int, error) {
-	n, err := c.Reader.Read(b)
-	return n, err
+	return c.Reader.Read(b)
 }
 
 func (c IOConn) Write(b []byte) (int, error) {
-	n, err := c.Writer.Write(b)
-	return n, err
+	return c.Writer.Write(b)
 }
 
 func (c IOConn) Close() error {

--- a/host/types/cmd.go
+++ b/host/types/cmd.go
@@ -79,9 +79,9 @@ func (ws *WaitStatus) String() string {
 			str += fmt.Sprintf(" from signal %v", ws.Signal)
 		}
 	} else {
-		str = "Process did not exit:"
+		str = "Process did not exit"
 		if ws.Signal != "" {
-			str += fmt.Sprintf(" received signal: %#v", ws.Signal)
+			str += fmt.Sprintf(": received signal: %#v", ws.Signal)
 		}
 	}
 


### PR DESCRIPTION
We randomly hit this case:

```
  🖥 Host
    type: ssh
    name: n2p.local
    DEBUG Close
  ERROR failed to close host
    error:
      failed to run /tmp/resonance_agent.L1IPYkml : write |1: broken pipe
      Process did not exit:
```

Root cause seems to be race condition between the gRPC client & server, which have left over bufferett things that attempt to go through the SSH session that's ended when the process exits.

This PR changes the shutdown mechanics:

- It asks the agent to shutdown itself by calling the CLI again, and the CLI identifies running process, and asks for them to stop gracefully.
- It makes the agent remove itself, so there's no junk left behind (tangent bug also fixed).