### PR TITLE
Fix shutdown race

### DIFF
--- a/host/agent_server/main_linux.go
+++ b/host/agent_server/main_linux.go
@@ -840,7 +840,7 @@ func main() {
 	doStop := len(os.Args) > 1 && os.Args[1] == "--stop"
 
 	defer func() {
-		if doStop {
+		if !doStop {
 			return
 		}
 		if err := os.Remove(os.Args[0]); err != nil {
@@ -865,7 +865,7 @@ func main() {
 	})
 
 	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, syscall.SIGTERM)
+	signal.Notify(signalCh, syscall.SIGTERM, syscall.SIGPIPE)
 	go func() {
 		<-signalCh
 		grpcServer.GracefulStop()


### PR DESCRIPTION
After we close the client, there's a tiny chance the server may try to write to the pipe, so it'll fail with SIGPIPE.

This PR:

- Handles this SIGPIPE.
- Moves the deletion of the file to the `--stop` call, otherwise the binary won't exist when we call it when SIGPIPE happens.